### PR TITLE
Add Get/ShowFullList function to some objects to obtain populated lists more efficiently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 .DS_Store
 *.swp
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ These functions correspond with PANOS `Get`, `Show`, `Set`, `Edit`, and `Delete`
 
 Some `Entry` objects have a special function, `Defaults()`.  Invoking this function will initialize the object with some default values.  Each `Entry` that implements `Defaults()` calls out in its documentation what parameters are affected by this, and what the defaults are.
 
+Some `Entry` objects have functions `GetFullList` and `ShowFullList()`. These operate differently than `GetList` and `ShowList` in that instead of returning lists of object names, they return populated lists of entries by obtaining a section of the Firewall's XML in one request. This makes them much more efficient in bulk configuration retreival use-cases.
+
 For any version safe object, attempting to configure a parameter that your PANOS doesn't support will be safely ignored in the resultant XML sent to the firewall / Panorama.
 
 

--- a/client.go
+++ b/client.go
@@ -1,23 +1,22 @@
 package pango
 
 import (
-    "bytes"
-    "crypto/tls"
-    "encoding/xml"
-    "fmt"
-    "io"
-    "io/ioutil"
-    "log"
-    "mime/multipart"
-    "net/http"
-    "net/url"
-    "strings"
-    "time"
+	"bytes"
+	"crypto/tls"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
-    "github.com/PaloAltoNetworks/pango/version"
-    "github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
 )
-
 
 // These bit flags control what is logged by client connections.  Of the flags
 // available for use, LogSend and LogReceive will log ALL communication between
@@ -37,85 +36,85 @@ import (
 //      * LogSend: xml docuemnt being sent
 //      * LogReceive: xml responses being received
 const (
-    LogQuiet = 1 << (iota + 1)
-    LogAction
-    LogQuery
-    LogOp
-    LogUid
-    LogXpath
-    LogSend
-    LogReceive
+	LogQuiet = 1 << (iota + 1)
+	LogAction
+	LogQuery
+	LogOp
+	LogUid
+	LogXpath
+	LogSend
+	LogReceive
 )
 
 // Client is a generic connector struct.  It provides wrapper functions for
 // invoking the various PAN-OS XPath API methods.  After creating the client,
 // invoke Initialize() to prepare it for use.
 type Client struct {
-    // Connection properties.
-    Hostname string
-    Username string
-    Password string
-    ApiKey string
-    Protocol string
-    Port uint
-    Timeout int
-    Target string
+	// Connection properties.
+	Hostname string
+	Username string
+	Password string
+	ApiKey   string
+	Protocol string
+	Port     uint
+	Timeout  int
+	Target   string
 
-    // HTTP transport options.  Note that the VerifyCertificate setting is
-    // only used if you do not specify a HTTP transport yourself.
-    VerifyCertificate bool
-    Transport *http.Transport
+	// HTTP transport options.  Note that the VerifyCertificate setting is
+	// only used if you do not specify a HTTP transport yourself.
+	VerifyCertificate bool
+	Transport         *http.Transport
 
-    // Variables determined at runtime.
-    Version version.Number
-    SystemInfo map[string] string
-    Plugin []map[string] string
+	// Variables determined at runtime.
+	Version    version.Number
+	SystemInfo map[string]string
+	Plugin     []map[string]string
 
-    // Logging level.
-    Logging uint32
+	// Logging level.
+	Logging uint32
 
-    // Internal variables.
-    con *http.Client
-    api_url string
+	// Internal variables.
+	con     *http.Client
+	api_url string
 
-    // Variables for testing, response bytes and response index.
-    rp []url.Values
-    rb [][]byte
-    ri int
+	// Variables for testing, response bytes and response index.
+	rp []url.Values
+	rb [][]byte
+	ri int
 }
 
 // String is the string representation of a client connection.  Both the
 // password and API key are replaced with stars, if set, making it safe
 // to print the client connection in log messages.
 func (c *Client) String() string {
-    var passwd string
-    var api_key string
+	var passwd string
+	var api_key string
 
-    if c.Password == "" {
-        passwd = ""
-    } else {
-        passwd = "********"
-    }
+	if c.Password == "" {
+		passwd = ""
+	} else {
+		passwd = "********"
+	}
 
-    if c.ApiKey == "" {
-        api_key = ""
-    } else {
-        api_key = "********"
-    }
+	if c.ApiKey == "" {
+		api_key = ""
+	} else {
+		api_key = "********"
+	}
 
-    return fmt.Sprintf(
-        "{Hostname:%s Username:%s Password:%s ApiKey:%s Protocol:%s Port:%d Timeout:%d Logging:%d}",
-        c.Hostname, c.Username, passwd, api_key, c.Protocol, c.Port, c.Timeout, c.Logging)
+	return fmt.Sprintf(
+		"{Hostname:%s Username:%s Password:%s ApiKey:%s Protocol:%s Port:%d Timeout:%d Logging:%d}",
+		c.Hostname, c.Username, passwd, api_key, c.Protocol, c.Port, c.Timeout, c.Logging)
 }
 
 // Versioning returns the client version number.
 func (c *Client) Versioning() version.Number {
-    return c.Version
+	return c.Version
 }
 
 // Plugins returns the plugin information.
-func (c *Client) Plugins() []map[string] string {
-    return c.Plugin
+func (c *Client) Plugins() []map[string]string {
+	return c.Plugin
 }
 
 // Initialize does some initial setup of the Client connection, retrieves
@@ -129,22 +128,22 @@ func (c *Client) Plugins() []map[string] string {
 //  * Timeout: 10
 //  * Logging: LogAction | LogUid
 func (c *Client) Initialize() error {
-    if len(c.rb) == 0 {
-        var e error
+	if len(c.rb) == 0 {
+		var e error
 
-        if e = c.initCon(); e != nil {
-            return e
-        } else if e = c.initApiKey(); e != nil {
-            return e
-        } else if e = c.initSystemInfo(); e != nil {
-            return e
-        }
-    } else {
-        c.Hostname = "localhost"
-        c.ApiKey = "password"
-    }
+		if e = c.initCon(); e != nil {
+			return e
+		} else if e = c.initApiKey(); e != nil {
+			return e
+		} else if e = c.initSystemInfo(); e != nil {
+			return e
+		}
+	} else {
+		c.Hostname = "localhost"
+		c.ApiKey = "password"
+	}
 
-    return nil
+	return nil
 }
 
 // RetrieveApiKey retrieves the API key, which will require that both the
@@ -152,109 +151,120 @@ func (c *Client) Initialize() error {
 //
 // The currently set ApiKey is forgotten when invoking this function.
 func (c *Client) RetrieveApiKey() error {
-    c.LogAction("%s: Retrieving API key", c.Hostname)
+	c.LogAction("%s: Retrieving API key", c.Hostname)
 
-    type key_gen_ans struct {
-        Key string `xml:"result>key"`
-    }
+	type key_gen_ans struct {
+		Key string `xml:"result>key"`
+	}
 
-    c.ApiKey = ""
-    ans := key_gen_ans{}
-    data := url.Values{}
-    data.Add("user", c.Username)
-    data.Add("password", c.Password)
-    data.Add("type", "keygen")
+	c.ApiKey = ""
+	ans := key_gen_ans{}
+	data := url.Values{}
+	data.Add("user", c.Username)
+	data.Add("password", c.Password)
+	data.Add("type", "keygen")
 
-    _, err := c.Communicate(data, &ans)
-    if err != nil {
-        return err
-    }
+	_, err := c.Communicate(data, &ans)
+	if err != nil {
+		return err
+	}
 
-    c.ApiKey = ans.Key
+	c.ApiKey = ans.Key
 
-    return nil
+	return nil
 }
 
 // EntryListUsing retrieves an list of entries using the given function, either
 // Get or Show.
 func (c *Client) EntryListUsing(fn util.Retriever, path []string) ([]string, error) {
-    var err error
-    type Entry struct {
-        Name string `xml:"name,attr"`
-    }
+	var err error
+	type Entry struct {
+		Name string `xml:"name,attr"`
+	}
 
-    type resp_struct struct {
-        Entries []Entry `xml:"result>entry"`
-    }
+	type resp_struct struct {
+		Entries []Entry `xml:"result>entry"`
+	}
 
-    if path == nil {
-        return nil, fmt.Errorf("xpath is empty")
-    }
-    path = append(path, "entry", "@name")
-    resp := resp_struct{}
+	if path == nil {
+		return nil, fmt.Errorf("xpath is empty")
+	}
+	path = append(path, "entry", "@name")
+	resp := resp_struct{}
 
-    _, err = fn(path, nil, &resp)
-    if err != nil {
-        e2, ok := err.(PanosError)
-        if ok && e2.ObjectNotFound() {
-            return nil, nil
-        }
-        return nil, err
-    }
+	_, err = fn(path, nil, &resp)
+	if err != nil {
+		e2, ok := err.(PanosError)
+		if ok && e2.ObjectNotFound() {
+			return nil, nil
+		}
+		return nil, err
+	}
 
-    ans := make([]string, len(resp.Entries))
-    for i := range resp.Entries {
-        ans[i] = resp.Entries[i].Name
-    }
+	ans := make([]string, len(resp.Entries))
+	for i := range resp.Entries {
+		ans[i] = resp.Entries[i].Name
+	}
 
-    return ans, nil
+	return ans, nil
+}
+
+// EntryObjectsUsing retreives raw xml tree at a given xpath using either get or show
+// and parses it into object pointed to by the last argument
+func (c *Client) EntryObjectsUsing(fn util.Retriever, path []string, target interface{}) error {
+	data, err := fn(path, nil, nil)
+	if err != nil {
+		return err
+	}
+	err = xml.Unmarshal(data, target)
+	return err
 }
 
 // MemberListUsing retrieves an list of members using the given function, either
 // Get or Show.
 func (c *Client) MemberListUsing(fn util.Retriever, path []string) ([]string, error) {
-    type resp_struct struct {
-        Members []string `xml:"result>member"`
-    }
+	type resp_struct struct {
+		Members []string `xml:"result>member"`
+	}
 
-    if path == nil {
-        return nil, fmt.Errorf("xpath is empty")
-    }
-    path = append(path, "member")
-    resp := resp_struct{}
+	if path == nil {
+		return nil, fmt.Errorf("xpath is empty")
+	}
+	path = append(path, "member")
+	resp := resp_struct{}
 
-    _, err := fn(path, nil, &resp)
-    if err != nil {
-        e2, ok := err.(PanosError)
-        if ok && e2.ObjectNotFound() {
-            return nil, nil
-        }
-        return nil, err
-    }
+	_, err := fn(path, nil, &resp)
+	if err != nil {
+		e2, ok := err.(PanosError)
+		if ok && e2.ObjectNotFound() {
+			return nil, nil
+		}
+		return nil, err
+	}
 
-    return resp.Members, nil
+	return resp.Members, nil
 }
 
 // RequestPasswordHash requests a password hash of the given string.
 func (c *Client) RequestPasswordHash(val string) (string, error) {
-    c.LogOp("(op) creating password hash")
-    type phash_req struct {
-        XMLName xml.Name `xml:"request"`
-        Val string `xml:"password-hash>password"`
-    }
+	c.LogOp("(op) creating password hash")
+	type phash_req struct {
+		XMLName xml.Name `xml:"request"`
+		Val     string   `xml:"password-hash>password"`
+	}
 
-    type phash_ans struct {
-        Hash string `xml:"result>phash"`
-    }
+	type phash_ans struct {
+		Hash string `xml:"result>phash"`
+	}
 
-    req := phash_req{Val: val}
-    ans := phash_ans{}
+	req := phash_req{Val: val}
+	ans := phash_ans{}
 
-    if _, err := c.Op(req, "", nil, &ans); err != nil {
-        return "", err
-    }
+	if _, err := c.Op(req, "", nil, &ans); err != nil {
+		return "", err
+	}
 
-    return ans.Hash, nil
+	return ans.Hash, nil
 }
 
 // ValidateConfig performs a commit config validation check.
@@ -264,127 +274,127 @@ func (c *Client) RequestPasswordHash(val string) (string, error) {
 //
 // This function returns the job ID and if any errors were encountered.
 func (c *Client) ValidateConfig(sync bool) (uint, error) {
-    var err error
+	var err error
 
-    c.LogOp("(op) validating config")
-    type op_req struct {
-        XMLName xml.Name `xml:"validate"`
-        Cmd string `xml:"full"`
-    }
-    job_ans := util.JobResponse{}
-    _, err = c.Op(op_req{}, "", nil, &job_ans)
-    if err != nil {
-        return 0, err
-    }
+	c.LogOp("(op) validating config")
+	type op_req struct {
+		XMLName xml.Name `xml:"validate"`
+		Cmd     string   `xml:"full"`
+	}
+	job_ans := util.JobResponse{}
+	_, err = c.Op(op_req{}, "", nil, &job_ans)
+	if err != nil {
+		return 0, err
+	}
 
-    id := job_ans.Id
-    if !sync {
-        return id, nil
-    }
+	id := job_ans.Id
+	if !sync {
+		return id, nil
+	}
 
-    return id, c.WaitForJob(id, nil)
+	return id, c.WaitForJob(id, nil)
 }
 
 // RevertToRunningConfig discards any changes made and reverts to the last
 // config committed.
 func (c *Client) RevertToRunningConfig() error {
-    c.LogOp("(op) reverting to running config")
-    _, err := c.Op("<load><config><from>running-config.xml</from></config></load>", "", nil, nil)
-    return err
+	c.LogOp("(op) reverting to running config")
+	_, err := c.Op("<load><config><from>running-config.xml</from></config></load>", "", nil, nil)
+	return err
 }
 
 // ConfigLocks returns any config locks that are currently in place.
 //
 // If vsys is an empty string, then the vsys will default to "shared".
 func (c *Client) ConfigLocks(vsys string) ([]util.Lock, error) {
-    if vsys == "" {
-        vsys = "shared"
-    }
+	if vsys == "" {
+		vsys = "shared"
+	}
 
-    c.LogOp("(op) getting config locks for scope %q", vsys)
-    ans := configLocks{}
-    _, err := c.Op("<show><config-locks /></show>", vsys, nil, &ans)
-    if err != nil {
-        return nil, err
-    }
-    return ans.Locks, nil
+	c.LogOp("(op) getting config locks for scope %q", vsys)
+	ans := configLocks{}
+	_, err := c.Op("<show><config-locks /></show>", vsys, nil, &ans)
+	if err != nil {
+		return nil, err
+	}
+	return ans.Locks, nil
 }
 
 // LockConfig locks the config for the given scope with the given comment.
 //
 // If vsys is an empty string, the scope defaults to "shared".
 func (c *Client) LockConfig(vsys, comment string) error {
-    if vsys == "" {
-        vsys = "shared"
-    }
-    c.LogOp("(op) locking config for scope %q", vsys)
+	if vsys == "" {
+		vsys = "shared"
+	}
+	c.LogOp("(op) locking config for scope %q", vsys)
 
-    var inner string
-    if comment == "" {
-        inner = "<add />"
-    } else {
-        inner = fmt.Sprintf("<add><comment>%s</comment></add>", comment)
-    }
-    cmd := fmt.Sprintf("<request><config-lock>%s</config-lock></request>", inner)
+	var inner string
+	if comment == "" {
+		inner = "<add />"
+	} else {
+		inner = fmt.Sprintf("<add><comment>%s</comment></add>", comment)
+	}
+	cmd := fmt.Sprintf("<request><config-lock>%s</config-lock></request>", inner)
 
-    _, err := c.Op(cmd, vsys, nil, nil)
-    return err
+	_, err := c.Op(cmd, vsys, nil, nil)
+	return err
 }
 
 // UnlockConfig removes the config lock on the given scope.
 //
 // If vsys is an empty string, the scope defaults to "shared".
 func (c *Client) UnlockConfig(vsys string) error {
-    if vsys == "" {
-        vsys = "shared"
-    }
+	if vsys == "" {
+		vsys = "shared"
+	}
 
-    type cmd struct {
-        XMLName xml.Name `xml:"request"`
-        Cmd string `xml:"config-lock>remove"`
-    }
+	type cmd struct {
+		XMLName xml.Name `xml:"request"`
+		Cmd     string   `xml:"config-lock>remove"`
+	}
 
-    c.LogOp("(op) unlocking config for scope %q", vsys)
-    _, err := c.Op(cmd{}, vsys, nil, nil)
-    return err
+	c.LogOp("(op) unlocking config for scope %q", vsys)
+	_, err := c.Op(cmd{}, vsys, nil, nil)
+	return err
 }
 
 // CommitLocks returns any commit locks that are currently in place.
 //
 // If vsys is an empty string, then the vsys will default to "shared".
 func (c *Client) CommitLocks(vsys string) ([]util.Lock, error) {
-    if vsys == "" {
-        vsys = "shared"
-    }
+	if vsys == "" {
+		vsys = "shared"
+	}
 
-    c.LogOp("(op) getting commit locks for scope %q", vsys)
-    ans := commitLocks{}
-    _, err := c.Op("<show><commit-locks /></show>", vsys, nil, &ans)
-    if err != nil {
-        return nil, err
-    }
-    return ans.Locks, nil
+	c.LogOp("(op) getting commit locks for scope %q", vsys)
+	ans := commitLocks{}
+	_, err := c.Op("<show><commit-locks /></show>", vsys, nil, &ans)
+	if err != nil {
+		return nil, err
+	}
+	return ans.Locks, nil
 }
 
 // LockCommits locks commits for the given scope with the given comment.
 //
 // If vsys is an empty string, the scope defaults to "shared".
 func (c *Client) LockCommits(vsys, comment string) error {
-    if vsys == "" {
-        vsys = "shared"
-    }
-    c.LogOp("(op) locking commits for scope %q", vsys)
+	if vsys == "" {
+		vsys = "shared"
+	}
+	c.LogOp("(op) locking commits for scope %q", vsys)
 
-    var inner string
-    if comment == "" {
-        inner = "<add />"
-    } else {
-        inner = fmt.Sprintf("<add><comment>%s</comment></add>", comment)
-    }
-    cmd := fmt.Sprintf("<request><commit-lock>%s</commit-lock></request>", inner)
+	var inner string
+	if comment == "" {
+		inner = "<add />"
+	} else {
+		inner = fmt.Sprintf("<add><comment>%s</comment></add>", comment)
+	}
+	cmd := fmt.Sprintf("<request><commit-lock>%s</commit-lock></request>", inner)
 
-    _, err := c.Op(cmd, vsys, nil, nil)
-    return err
+	_, err := c.Op(cmd, vsys, nil, nil)
+	return err
 }
 
 // UnlockCommits removes the commit lock on the given scope owned by the given
@@ -392,18 +402,18 @@ func (c *Client) LockCommits(vsys, comment string) error {
 //
 // If vsys is an empty string, the scope defaults to "shared".
 func (c *Client) UnlockCommits(vsys, admin string) error {
-    if vsys == "" {
-        vsys = "shared"
-    }
+	if vsys == "" {
+		vsys = "shared"
+	}
 
-    type cmd struct {
-        XMLName xml.Name `xml:"request"`
-        Admin string `xml:"commit-lock>remove>admin,omitempty"`
-    }
+	type cmd struct {
+		XMLName xml.Name `xml:"request"`
+		Admin   string   `xml:"commit-lock>remove>admin,omitempty"`
+	}
 
-    c.LogOp("(op) unlocking commits for scope %q", vsys)
-    _, err := c.Op(cmd{Admin: admin}, vsys, nil, nil)
-    return err
+	c.LogOp("(op) unlocking commits for scope %q", vsys)
+	_, err := c.Op(cmd{Admin: admin}, vsys, nil, nil)
+	return err
 }
 
 // Commit performs a standard commit on this PAN-OS device.
@@ -428,29 +438,29 @@ func (c *Client) UnlockCommits(vsys, admin string) error {
 // if an error was encountered or not are returned from this function.  If
 // the job ID returned is 0, then no commit was needed.
 func (c *Client) Commit(desc string, admins []string, dan, pao, force, sync bool) (uint, error) {
-    c.LogAction("(commit) %q", desc)
+	c.LogAction("(commit) %q", desc)
 
-    req := baseCommit{Description: desc}
-    if len(admins) > 0 || !dan || !pao {
-        req.Partial = &baseCommitPartial{}
-        if !dan {
-            req.Partial.Dan = "excluded"
-        }
-        if !pao {
-            req.Partial.Pao = "excluded"
-        }
-	req.Partial.Admin = util.StrToMem(admins)
-    }
-    if force {
-        req.Force = ""
-    }
+	req := baseCommit{Description: desc}
+	if len(admins) > 0 || !dan || !pao {
+		req.Partial = &baseCommitPartial{}
+		if !dan {
+			req.Partial.Dan = "excluded"
+		}
+		if !pao {
+			req.Partial.Pao = "excluded"
+		}
+		req.Partial.Admin = util.StrToMem(admins)
+	}
+	if force {
+		req.Force = ""
+	}
 
-    job, _, err := c.CommitConfig(req, "", nil)
-    if err != nil || !sync || job == 0 {
-        return job, err
-    }
+	job, _, err := c.CommitConfig(req, "", nil)
+	if err != nil || !sync || job == 0 {
+		return job, err
+	}
 
-    return job, c.WaitForJob(job, nil)
+	return job, c.WaitForJob(job, nil)
 }
 
 // WaitForJob polls the device, waiting for the specified job to finish.
@@ -463,104 +473,104 @@ func (c *Client) Commit(desc string, admins []string, dan, pao, force, sync bool
 // In the case that there are multiple errors returned from the job, the first
 // error is returned as the error string, and no unmarshaling is attempted.
 func (c *Client) WaitForJob(id uint, resp interface{}) error {
-    var err error
-    var prev uint
-    var data []byte
-    dp := false
-    all_ok := true
+	var err error
+	var prev uint
+	var data []byte
+	dp := false
+	all_ok := true
 
-    c.LogOp("(op) waiting for job %d", id)
-    type op_req struct {
-        XMLName xml.Name `xml:"show"`
-        Id uint `xml:"jobs>id"`
-    }
-    req := op_req{Id: id}
+	c.LogOp("(op) waiting for job %d", id)
+	type op_req struct {
+		XMLName xml.Name `xml:"show"`
+		Id      uint     `xml:"jobs>id"`
+	}
+	req := op_req{Id: id}
 
-    var ans util.BasicJob
-    for {
-        // We need to zero out the response each iteration because the slices
-        // of strings append to each other instead of zeroing out.
-        ans = util.BasicJob{}
+	var ans util.BasicJob
+	for {
+		// We need to zero out the response each iteration because the slices
+		// of strings append to each other instead of zeroing out.
+		ans = util.BasicJob{}
 
-        // Get current percent complete.
-        data, err = c.Op(req, "", nil, &ans)
-        if err != nil {
-            return err
-        }
+		// Get current percent complete.
+		data, err = c.Op(req, "", nil, &ans)
+		if err != nil {
+			return err
+		}
 
-        // Output percent complete if it's new.
-        if ans.Progress != prev {
-            prev = ans.Progress
-            c.LogOp("(op) job %d: %d percent complete", id, prev)
-        }
+		// Output percent complete if it's new.
+		if ans.Progress != prev {
+			prev = ans.Progress
+			c.LogOp("(op) job %d: %d percent complete", id, prev)
+		}
 
-        // Check for device commits.
-        all_done := true
-        for _, d := range ans.Devices {
-            c.LogOp("%q result: %s", d.Serial, d.Result)
-            if d.Result == "PEND" {
-                all_done = false
-                break
-            } else if d.Result != "OK" && all_ok {
-                all_ok = false
-            }
-        }
+		// Check for device commits.
+		all_done := true
+		for _, d := range ans.Devices {
+			c.LogOp("%q result: %s", d.Serial, d.Result)
+			if d.Result == "PEND" {
+				all_done = false
+				break
+			} else if d.Result != "OK" && all_ok {
+				all_ok = false
+			}
+		}
 
-        // Check for end condition.
-        if ans.Progress == 100 {
-            if all_done {
-                break
-            } else if !dp {
-                c.LogOp("(op) Waiting for %d device commits ...", len(ans.Devices))
-                dp = true
-            }
-        }
-    }
+		// Check for end condition.
+		if ans.Progress == 100 {
+			if all_done {
+				break
+			} else if !dp {
+				c.LogOp("(op) Waiting for %d device commits ...", len(ans.Devices))
+				dp = true
+			}
+		}
+	}
 
-    // Check the results for a failed commit.
-    if ans.Result == "FAIL" {
-        if len(ans.Details) > 0 {
-            return fmt.Errorf(ans.Details[0])
-        } else {
-            return fmt.Errorf("Job %d has failed to complete successfully", id)
-        }
-    } else if !all_ok {
-        return fmt.Errorf("Commit failed on one or more devices")
-    }
+	// Check the results for a failed commit.
+	if ans.Result == "FAIL" {
+		if len(ans.Details) > 0 {
+			return fmt.Errorf(ans.Details[0])
+		} else {
+			return fmt.Errorf("Job %d has failed to complete successfully", id)
+		}
+	} else if !all_ok {
+		return fmt.Errorf("Commit failed on one or more devices")
+	}
 
-    if resp == nil {
-        return nil
-    }
+	if resp == nil {
+		return nil
+	}
 
-    return xml.Unmarshal(data, resp)
+	return xml.Unmarshal(data, resp)
 }
 
 // LogAction writes a log message for SET/DELETE operations if LogAction is set.
 func (c *Client) LogAction(msg string, i ...interface{}) {
-    if c.Logging & LogAction == LogAction {
-        log.Printf(msg, i...)
-    }
+	if c.Logging&LogAction == LogAction {
+		log.Printf(msg, i...)
+	}
 }
 
 // LogQuery writes a log message for GET/SHOW operations if LogQuery is set.
 func (c *Client) LogQuery(msg string, i ...interface{}) {
-    if c.Logging & LogQuery == LogQuery {
-        log.Printf(msg, i...)
-    }
+	if c.Logging&LogQuery == LogQuery {
+		log.Printf(msg, i...)
+	}
 }
 
 // LogOp writes a log message for OP operations if LogOp is set.
 func (c *Client) LogOp(msg string, i ...interface{}) {
-    if c.Logging & LogOp == LogOp {
-        log.Printf(msg, i...)
-    }
+	if c.Logging&LogOp == LogOp {
+		log.Printf(msg, i...)
+	}
 }
 
 // LogUid writes a log message for User-Id operations if LogUid is set.
 func (c *Client) LogUid(msg string, i ...interface{}) {
-    if c.Logging & LogUid == LogUid {
-        log.Printf(msg, i...)
-    }
+	if c.Logging&LogUid == LogUid {
+		log.Printf(msg, i...)
+	}
 }
 
 // Communicate sends the given data to PAN-OS.
@@ -577,27 +587,27 @@ func (c *Client) LogUid(msg string, i ...interface{}) {
 //
 // If the API key is set, but not present in the given data, then it is added in.
 func (c *Client) Communicate(data url.Values, ans interface{}) ([]byte, error) {
-    if c.ApiKey != "" && data.Get("key") == "" {
-        data.Set("key", c.ApiKey)
-    }
+	if c.ApiKey != "" && data.Get("key") == "" {
+		data.Set("key", c.ApiKey)
+	}
 
-    if c.Logging & LogSend == LogSend {
-        old_key := data.Get("key")
-        if old_key != "" {
-            data.Set("key", "########")
-        }
-        log.Printf("Sending data: %#v", data)
-        if old_key != "" {
-            data.Set("key", old_key)
-        }
-    }
+	if c.Logging&LogSend == LogSend {
+		old_key := data.Get("key")
+		if old_key != "" {
+			data.Set("key", "########")
+		}
+		log.Printf("Sending data: %#v", data)
+		if old_key != "" {
+			data.Set("key", old_key)
+		}
+	}
 
-    body, err := c.post(data)
-    if err != nil {
-        return nil, err
-    }
+	body, err := c.post(data)
+	if err != nil {
+		return nil, err
+	}
 
-    return c.endCommunication(body, ans)
+	return c.endCommunication(body, ans)
 }
 
 // CommunicateFile does a file upload to PAN-OS.
@@ -621,59 +631,59 @@ func (c *Client) Communicate(data url.Values, ans interface{}) ([]byte, error) {
 //
 // If the API key is set, but not present in the given data, then it is added in.
 func (c *Client) CommunicateFile(content, filename, fp string, data url.Values, ans interface{}) ([]byte, error) {
-    var err error
+	var err error
 
-    if c.ApiKey != "" && data.Get("key") == "" {
-        data.Set("key", c.ApiKey)
-    }
+	if c.ApiKey != "" && data.Get("key") == "" {
+		data.Set("key", c.ApiKey)
+	}
 
-    if c.Logging & LogSend == LogSend {
-        old_key := data.Get("key")
-        if old_key != "" {
-            data.Set("key", "########")
-        }
-        log.Printf("Sending data: %#v", data)
-        if old_key != "" {
-            data.Set("key", old_key)
-        }
-    }
+	if c.Logging&LogSend == LogSend {
+		old_key := data.Get("key")
+		if old_key != "" {
+			data.Set("key", "########")
+		}
+		log.Printf("Sending data: %#v", data)
+		if old_key != "" {
+			data.Set("key", old_key)
+		}
+	}
 
-    buf := bytes.Buffer{}
-    w := multipart.NewWriter(&buf)
+	buf := bytes.Buffer{}
+	w := multipart.NewWriter(&buf)
 
-    for k := range data {
-        w.WriteField(k, data.Get(k))
-    }
+	for k := range data {
+		w.WriteField(k, data.Get(k))
+	}
 
-    w2, err := w.CreateFormFile(fp, filename)
-    if err != nil {
-        return nil, err
-    }
+	w2, err := w.CreateFormFile(fp, filename)
+	if err != nil {
+		return nil, err
+	}
 
-    if _, err = io.Copy(w2, strings.NewReader(content)); err != nil {
-        return nil, err
-    }
+	if _, err = io.Copy(w2, strings.NewReader(content)); err != nil {
+		return nil, err
+	}
 
-    w.Close()
+	w.Close()
 
-    req, err := http.NewRequest("POST", c.api_url, &buf)
-    if err != nil {
-        return nil, err
-    }
-    req.Header.Set("Content-Type", w.FormDataContentType())
+	req, err := http.NewRequest("POST", c.api_url, &buf)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
 
-    res, err := c.con.Do(req)
-    if err != nil {
-        return nil, err
-    }
+	res, err := c.con.Do(req)
+	if err != nil {
+		return nil, err
+	}
 
-    defer res.Body.Close()
-    body, err := ioutil.ReadAll(res.Body)
-    if err != nil {
-        return nil, err
-    }
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
 
-    return c.endCommunication(body, ans)
+	return c.endCommunication(body, ans)
 }
 
 // Op runs an operational or "op" type command.
@@ -692,27 +702,27 @@ func (c *Client) CommunicateFile(content, filename, fp string, data url.Values, 
 // Any response received from the server is returned, along with any errors
 // encountered.
 func (c *Client) Op(req interface{}, vsys string, extras, ans interface{}) ([]byte, error) {
-    var err error
-    data := url.Values{}
-    data.Set("type", "op")
+	var err error
+	data := url.Values{}
+	data.Set("type", "op")
 
-    if err = addToData("cmd", req, true, &data); err != nil {
-        return nil, err
-    }
+	if err = addToData("cmd", req, true, &data); err != nil {
+		return nil, err
+	}
 
-    if vsys != "" {
-        data.Set("vsys", vsys)
-    }
+	if vsys != "" {
+		data.Set("vsys", vsys)
+	}
 
-    if c.Target != "" {
-        data.Set("target", c.Target)
-    }
+	if c.Target != "" {
+		data.Set("target", c.Target)
+	}
 
-    if err = mergeUrlValues(&data, extras); err != nil {
-        return nil, err
-    }
+	if err = mergeUrlValues(&data, extras); err != nil {
+		return nil, err
+	}
 
-    return c.Communicate(data, ans)
+	return c.Communicate(data, ans)
 }
 
 // Show runs a "show" type command.
@@ -728,12 +738,12 @@ func (c *Client) Op(req interface{}, vsys string, extras, ans interface{}) ([]by
 // Any response received from the server is returned, along with any errors
 // encountered.
 func (c *Client) Show(path, extras, ans interface{}) ([]byte, error) {
-    data := url.Values{}
-    xp := util.AsXpath(path)
-    c.logXpath(xp)
-    data.Set("xpath", xp)
+	data := url.Values{}
+	xp := util.AsXpath(path)
+	c.logXpath(xp)
+	data.Set("xpath", xp)
 
-    return c.typeConfig("show", data, extras, ans)
+	return c.typeConfig("show", data, extras, ans)
 }
 
 // Get runs a "get" type command.
@@ -749,12 +759,12 @@ func (c *Client) Show(path, extras, ans interface{}) ([]byte, error) {
 // Any response received from the server is returned, along with any errors
 // encountered.
 func (c *Client) Get(path, extras, ans interface{}) ([]byte, error) {
-    data := url.Values{}
-    xp := util.AsXpath(path)
-    c.logXpath(xp)
-    data.Set("xpath", xp)
+	data := url.Values{}
+	xp := util.AsXpath(path)
+	c.logXpath(xp)
+	data.Set("xpath", xp)
 
-    return c.typeConfig("get", data, extras, ans)
+	return c.typeConfig("get", data, extras, ans)
 }
 
 // Delete runs a "delete" type command, removing the supplied xpath and
@@ -771,12 +781,12 @@ func (c *Client) Get(path, extras, ans interface{}) ([]byte, error) {
 // Any response received from the server is returned, along with any errors
 // encountered.
 func (c *Client) Delete(path, extras, ans interface{}) ([]byte, error) {
-    data := url.Values{}
-    xp := util.AsXpath(path)
-    c.logXpath(xp)
-    data.Set("xpath", xp)
+	data := url.Values{}
+	xp := util.AsXpath(path)
+	c.logXpath(xp)
+	data.Set("xpath", xp)
 
-    return c.typeConfig("delete", data, extras, ans)
+	return c.typeConfig("delete", data, extras, ans)
 }
 
 // Set runs a "set" type command, creating the element at the given xpath.
@@ -795,17 +805,17 @@ func (c *Client) Delete(path, extras, ans interface{}) ([]byte, error) {
 // Any response received from the server is returned, along with any errors
 // encountered.
 func (c *Client) Set(path, element, extras, ans interface{}) ([]byte, error) {
-    var err error
-    data := url.Values{}
-    xp := util.AsXpath(path)
-    c.logXpath(xp)
-    data.Set("xpath", xp)
+	var err error
+	data := url.Values{}
+	xp := util.AsXpath(path)
+	c.logXpath(xp)
+	data.Set("xpath", xp)
 
-    if err = addToData("element", element, true, &data); err != nil {
-        return nil, err
-    }
+	if err = addToData("element", element, true, &data); err != nil {
+		return nil, err
+	}
 
-    return c.typeConfig("set", data, extras, ans)
+	return c.typeConfig("set", data, extras, ans)
 }
 
 // Edit runs a "edit" type command, modifying what is at the given xpath
@@ -825,60 +835,60 @@ func (c *Client) Set(path, element, extras, ans interface{}) ([]byte, error) {
 // Any response received from the server is returned, along with any errors
 // encountered.
 func (c *Client) Edit(path, element, extras, ans interface{}) ([]byte, error) {
-    var err error
-    data := url.Values{}
-    xp := util.AsXpath(path)
-    c.logXpath(xp)
-    data.Set("xpath", xp)
+	var err error
+	data := url.Values{}
+	xp := util.AsXpath(path)
+	c.logXpath(xp)
+	data.Set("xpath", xp)
 
-    if err = addToData("element", element, true, &data); err != nil {
-        return nil, err
-    }
+	if err = addToData("element", element, true, &data); err != nil {
+		return nil, err
+	}
 
-    return c.typeConfig("edit", data, extras, ans)
+	return c.typeConfig("edit", data, extras, ans)
 }
 
 // Move does a "move" type command.
 func (c *Client) Move(path interface{}, where, dst string, extras, ans interface{}) ([]byte, error) {
-    data := url.Values{}
-    xp := util.AsXpath(path)
-    c.logXpath(xp)
-    data.Set("xpath", xp)
+	data := url.Values{}
+	xp := util.AsXpath(path)
+	c.logXpath(xp)
+	data.Set("xpath", xp)
 
-    if where != "" {
-        data.Set("where", where)
-    }
+	if where != "" {
+		data.Set("where", where)
+	}
 
-    if dst != "" {
-        data.Set("dst", dst)
-    }
+	if dst != "" {
+		data.Set("dst", dst)
+	}
 
-    return c.typeConfig("move", data, extras, ans)
+	return c.typeConfig("move", data, extras, ans)
 }
 
 // Uid performs User-ID API calls.
 func (c *Client) Uid(cmd interface{}, vsys string, extras, ans interface{}) ([]byte, error) {
-    var err error
-    data := url.Values{}
-    data.Set("type", "user-id")
+	var err error
+	data := url.Values{}
+	data.Set("type", "user-id")
 
-    if err = addToData("cmd", cmd, true, &data); err != nil {
-        return nil, err
-    }
+	if err = addToData("cmd", cmd, true, &data); err != nil {
+		return nil, err
+	}
 
-    if vsys != "" {
-        data.Set("vsys", vsys)
-    }
+	if vsys != "" {
+		data.Set("vsys", vsys)
+	}
 
-    if c.Target != "" {
-        data.Set("target", c.Target)
-    }
+	if c.Target != "" {
+		data.Set("target", c.Target)
+	}
 
-    if err = mergeUrlValues(&data, extras); err != nil {
-        return nil, err
-    }
+	if err = mergeUrlValues(&data, extras); err != nil {
+		return nil, err
+	}
 
-    return c.Communicate(data, ans)
+	return c.Communicate(data, ans)
 }
 
 // Import performs an import type command.
@@ -899,16 +909,16 @@ func (c *Client) Uid(cmd interface{}, vsys string, extras, ans interface{}) ([]b
 //
 // Any response received from the server is returned, along with any errors
 // encountered.
-func (c *Client) Import(cat, content, filename, fp string, extras map[string] string, ans interface{}) ([]byte, error) {
-    data := url.Values{}
-    data.Set("type", "import")
-    data.Set("category", cat)
+func (c *Client) Import(cat, content, filename, fp string, extras map[string]string, ans interface{}) ([]byte, error) {
+	data := url.Values{}
+	data.Set("type", "import")
+	data.Set("category", cat)
 
-    for k := range extras {
-        data.Set(k, extras[k])
-    }
+	for k := range extras {
+		data.Set(k, extras[k])
+	}
 
-    return c.CommunicateFile(content, filename, fp, data, ans)
+	return c.CommunicateFile(content, filename, fp, data, ans)
 }
 
 // CommitConfig performs PAN-OS commits.  This is the underlying function
@@ -926,302 +936,302 @@ func (c *Client) Import(cat, content, filename, fp string, extras map[string] st
 // the commit action was successfully submitted, the response from the server,
 // and if an error was encountered or not are all returned from this function.
 func (c *Client) CommitConfig(cmd interface{}, action string, extras interface{}) (uint, []byte, error) {
-    var err error
-    data := url.Values{}
-    data.Set("type", "commit")
+	var err error
+	data := url.Values{}
+	data.Set("type", "commit")
 
-    if err = addToData("cmd", cmd, true, &data); err != nil {
-        return 0, nil, err
-    }
+	if err = addToData("cmd", cmd, true, &data); err != nil {
+		return 0, nil, err
+	}
 
-    if action != "" {
-        data.Set("action", action)
-    }
+	if action != "" {
+		data.Set("action", action)
+	}
 
-    if c.Target != "" {
-        data.Set("target", c.Target)
-    }
+	if c.Target != "" {
+		data.Set("target", c.Target)
+	}
 
-    if err = mergeUrlValues(&data, extras); err != nil {
-        return 0, nil, err
-    }
+	if err = mergeUrlValues(&data, extras); err != nil {
+		return 0, nil, err
+	}
 
-    ans := util.JobResponse{}
-    b, err := c.Communicate(data, &ans)
-    return ans.Id, b, err
+	ans := util.JobResponse{}
+	b, err := c.Communicate(data, &ans)
+	return ans.Id, b, err
 }
 
 /*** Internal functions ***/
 
 func (c *Client) initCon() error {
-    var tout time.Duration
+	var tout time.Duration
 
-    // Sets the logging level.
-    if c.Logging == 0 {
-        c.Logging = LogAction | LogUid
-    }
+	// Sets the logging level.
+	if c.Logging == 0 {
+		c.Logging = LogAction | LogUid
+	}
 
-    // Set the timeout
-    if c.Timeout == 0 {
-        c.Timeout = 10
-    } else if c.Timeout > 60 {
-        return fmt.Errorf("Timeout for %q is %d, expecting a number between [0, 60]", c.Hostname, c.Timeout)
-    }
-    tout = time.Duration(time.Duration(c.Timeout) * time.Second)
+	// Set the timeout
+	if c.Timeout == 0 {
+		c.Timeout = 10
+	} else if c.Timeout > 60 {
+		return fmt.Errorf("Timeout for %q is %d, expecting a number between [0, 60]", c.Hostname, c.Timeout)
+	}
+	tout = time.Duration(time.Duration(c.Timeout) * time.Second)
 
-    // Set the protocol
-    if c.Protocol == "" {
-        c.Protocol = "https"
-    } else if c.Protocol != "http" && c.Protocol != "https" {
-        return fmt.Errorf("Invalid protocol %q.  Must be \"http\" or \"https\"", c.Protocol)
-    }
+	// Set the protocol
+	if c.Protocol == "" {
+		c.Protocol = "https"
+	} else if c.Protocol != "http" && c.Protocol != "https" {
+		return fmt.Errorf("Invalid protocol %q.  Must be \"http\" or \"https\"", c.Protocol)
+	}
 
-    // Check port number
-    if c.Port > 65535 {
-        return fmt.Errorf("Port %d is out of bounds", c.Port)
-    }
+	// Check port number
+	if c.Port > 65535 {
+		return fmt.Errorf("Port %d is out of bounds", c.Port)
+	}
 
-    // Setup the https client
-    if c.Transport == nil {
-        c.Transport = &http.Transport{
-            TLSClientConfig: &tls.Config{
-                InsecureSkipVerify: !c.VerifyCertificate,
-            },
-        }
-    }
-    c.con = &http.Client{
-        Transport: c.Transport,
-        Timeout: tout,
-    }
+	// Setup the https client
+	if c.Transport == nil {
+		c.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: !c.VerifyCertificate,
+			},
+		}
+	}
+	c.con = &http.Client{
+		Transport: c.Transport,
+		Timeout:   tout,
+	}
 
-    // Configure the api url
-    if c.Port == 0 {
-        c.api_url = fmt.Sprintf("%s://%s/api", c.Protocol, c.Hostname)
-    } else {
-        c.api_url = fmt.Sprintf("%s://%s:%d/api", c.Protocol, c.Hostname, c.Port)
-    }
+	// Configure the api url
+	if c.Port == 0 {
+		c.api_url = fmt.Sprintf("%s://%s/api", c.Protocol, c.Hostname)
+	} else {
+		c.api_url = fmt.Sprintf("%s://%s:%d/api", c.Protocol, c.Hostname, c.Port)
+	}
 
-    return nil
+	return nil
 }
 
 func (c *Client) initApiKey() error {
-    if c.ApiKey != "" {
-        return nil
-    }
+	if c.ApiKey != "" {
+		return nil
+	}
 
-    return c.RetrieveApiKey()
+	return c.RetrieveApiKey()
 }
 
 func (c *Client) initSystemInfo() error {
-    var err error
-    c.LogOp("(op) show system info")
+	var err error
+	c.LogOp("(op) show system info")
 
-    // Run "show system info"
-    type system_info_req struct {
-        XMLName xml.Name `xml:"show"`
-        Cmd string `xml:"system>info"`
-    }
+	// Run "show system info"
+	type system_info_req struct {
+		XMLName xml.Name `xml:"show"`
+		Cmd     string   `xml:"system>info"`
+	}
 
-    type tagVal struct {
-        XMLName xml.Name
-        Value string `xml:",chardata"`
-    }
+	type tagVal struct {
+		XMLName xml.Name
+		Value   string `xml:",chardata"`
+	}
 
-    type sysTag struct {
-        XMLName xml.Name `xml:"system"`
-        Tag []tagVal `xml:",any"`
-    }
+	type sysTag struct {
+		XMLName xml.Name `xml:"system"`
+		Tag     []tagVal `xml:",any"`
+	}
 
-    type system_info_ans struct {
-        System sysTag `xml:"result>system"`
-    }
+	type system_info_ans struct {
+		System sysTag `xml:"result>system"`
+	}
 
-    req := system_info_req{}
-    ans := system_info_ans{}
+	req := system_info_req{}
+	ans := system_info_ans{}
 
-    _, err = c.Op(req, "", nil, &ans)
-    if err != nil {
-        return fmt.Errorf("Error getting system info: %s", err)
-    }
+	_, err = c.Op(req, "", nil, &ans)
+	if err != nil {
+		return fmt.Errorf("Error getting system info: %s", err)
+	}
 
-    c.SystemInfo = make(map[string] string, len(ans.System.Tag))
-    for i := range ans.System.Tag {
-        c.SystemInfo[ans.System.Tag[i].XMLName.Local] = ans.System.Tag[i].Value
-        if ans.System.Tag[i].XMLName.Local == "sw-version" {
-            c.Version, err = version.New(ans.System.Tag[i].Value)
-            if err != nil {
-                return fmt.Errorf("Error parsing version %s: %s", ans.System.Tag[i].Value, err)
-            }
-        }
-    }
+	c.SystemInfo = make(map[string]string, len(ans.System.Tag))
+	for i := range ans.System.Tag {
+		c.SystemInfo[ans.System.Tag[i].XMLName.Local] = ans.System.Tag[i].Value
+		if ans.System.Tag[i].XMLName.Local == "sw-version" {
+			c.Version, err = version.New(ans.System.Tag[i].Value)
+			if err != nil {
+				return fmt.Errorf("Error parsing version %s: %s", ans.System.Tag[i].Value, err)
+			}
+		}
+	}
 
-    return nil
+	return nil
 }
 
 func (c *Client) typeConfig(action string, data url.Values, extras, ans interface{}) ([]byte, error) {
-    var err error
+	var err error
 
-    data.Set("type", "config")
-    data.Set("action", action)
-    if c.Target != "" {
-        data.Set("target", c.Target)
-    }
+	data.Set("type", "config")
+	data.Set("action", action)
+	if c.Target != "" {
+		data.Set("target", c.Target)
+	}
 
-    if err = mergeUrlValues(&data, extras); err != nil {
-        return nil, err
-    }
+	if err = mergeUrlValues(&data, extras); err != nil {
+		return nil, err
+	}
 
-    return c.Communicate(data, ans)
+	return c.Communicate(data, ans)
 }
 
 func (c *Client) logXpath(p string) {
-    if c.Logging & LogXpath == LogXpath {
-        log.Printf("(xpath) %s", p)
-    }
+	if c.Logging&LogXpath == LogXpath {
+		log.Printf("(xpath) %s", p)
+	}
 }
 
 // VsysImport imports the given names into the specified template / vsys.
 func (c *Client) VsysImport(loc, tmpl, ts, vsys string, names []string) error {
-    path := c.xpathImport(tmpl, ts, vsys)
-    if len(names) == 0 || vsys == "" {
-        return nil
-    } else if len(names) == 1 {
-        path = append(path, loc)
-    }
+	path := c.xpathImport(tmpl, ts, vsys)
+	if len(names) == 0 || vsys == "" {
+		return nil
+	} else if len(names) == 1 {
+		path = append(path, loc)
+	}
 
-    obj := util.BulkElement{XMLName: xml.Name{Local: loc}}
-    for i := range names {
-        obj.Data = append(obj.Data, vis{xml.Name{Local: "member"}, names[i]})
-    }
+	obj := util.BulkElement{XMLName: xml.Name{Local: loc}}
+	for i := range names {
+		obj.Data = append(obj.Data, vis{xml.Name{Local: "member"}, names[i]})
+	}
 
-    _, err := c.Set(path, obj.Config(), nil, nil)
-    return err
+	_, err := c.Set(path, obj.Config(), nil, nil)
+	return err
 }
 
 // VsysUnimport removes the given names from all (template, optional) vsys.
 func (c *Client) VsysUnimport(loc, tmpl, ts string, names []string) error {
-    if len(names) == 0 {
-        return nil
-    }
+	if len(names) == 0 {
+		return nil
+	}
 
-    path := make([]string, 0, 14)
-    path = append(path, c.xpathImport(tmpl, ts, "")...)
-    path = append(path, loc, util.AsMemberXpath(names))
+	path := make([]string, 0, 14)
+	path = append(path, c.xpathImport(tmpl, ts, "")...)
+	path = append(path, loc, util.AsMemberXpath(names))
 
-    _, err := c.Delete(path, nil, nil)
-    if err != nil {
-        e2, ok := err.(PanosError)
-        if ok && e2.ObjectNotFound() {
-            return nil
-        }
-    }
-    return err
+	_, err := c.Delete(path, nil, nil)
+	if err != nil {
+		e2, ok := err.(PanosError)
+		if ok && e2.ObjectNotFound() {
+			return nil
+		}
+	}
+	return err
 }
 
 // IsImported checks if the importable object is actually imported in the
 // specified location.
 func (c *Client) IsImported(loc, tmpl, ts, vsys, name string) (bool, error) {
-    path := make([]string, 0, 14)
-    path = append(path, c.xpathImport(tmpl, ts, vsys)...)
-    path = append(path, loc, util.AsMemberXpath([]string{name}))
+	path := make([]string, 0, 14)
+	path = append(path, c.xpathImport(tmpl, ts, vsys)...)
+	path = append(path, loc, util.AsMemberXpath([]string{name}))
 
-    _, err := c.Get(path, nil, nil)
-    if err == nil {
-        if vsys != "" {
-            return true, nil
-        } else {
-            return false, nil
-        }
-    }
+	_, err := c.Get(path, nil, nil)
+	if err == nil {
+		if vsys != "" {
+			return true, nil
+		} else {
+			return false, nil
+		}
+	}
 
-    e2, ok := err.(PanosError)
-    if ok && e2.ObjectNotFound() {
-        if vsys != "" {
-            return false, nil
-        } else {
-            return true, nil
-        }
-    }
+	e2, ok := err.(PanosError)
+	if ok && e2.ObjectNotFound() {
+		if vsys != "" {
+			return false, nil
+		} else {
+			return true, nil
+		}
+	}
 
-    return false, err
+	return false, err
 }
 
-func (c *Client) xpathImport(tmpl, ts, vsys string) ([]string) {
-    ans := make([]string, 0, 12)
-    if tmpl != "" || ts != "" {
-        ans = append(ans, util.TemplateXpathPrefix(tmpl, ts)...)
-    }
-    ans = append(ans,
-        "config",
-        "devices",
-        util.AsEntryXpath([]string{"localhost.localdomain"}),
-        "vsys",
-        util.AsEntryXpath([]string{vsys}),
-        "import",
-        "network",
-    )
+func (c *Client) xpathImport(tmpl, ts, vsys string) []string {
+	ans := make([]string, 0, 12)
+	if tmpl != "" || ts != "" {
+		ans = append(ans, util.TemplateXpathPrefix(tmpl, ts)...)
+	}
+	ans = append(ans,
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"vsys",
+		util.AsEntryXpath([]string{vsys}),
+		"import",
+		"network",
+	)
 
-    return ans
+	return ans
 }
 
 func (c *Client) post(data url.Values) ([]byte, error) {
-    if len(c.rb) == 0 {
-        r, err := c.con.PostForm(c.api_url, data)
-        if err != nil {
-            return nil, err
-        }
+	if len(c.rb) == 0 {
+		r, err := c.con.PostForm(c.api_url, data)
+		if err != nil {
+			return nil, err
+		}
 
-        defer r.Body.Close()
-        return ioutil.ReadAll(r.Body)
-    } else {
-        if c.ri < len(c.rb) {
-            c.rp = append(c.rp, data)
-        }
-        body := c.rb[c.ri % len(c.rb)]
-        c.ri++
-        return body, nil
-    }
+		defer r.Body.Close()
+		return ioutil.ReadAll(r.Body)
+	} else {
+		if c.ri < len(c.rb) {
+			c.rp = append(c.rp, data)
+		}
+		body := c.rb[c.ri%len(c.rb)]
+		c.ri++
+		return body, nil
+	}
 }
 
 func (c *Client) endCommunication(body []byte, ans interface{}) ([]byte, error) {
-    var err error
+	var err error
 
-    if c.Logging & LogReceive == LogReceive {
-        log.Printf("Response = %s", body)
-    }
+	if c.Logging&LogReceive == LogReceive {
+		log.Printf("Response = %s", body)
+	}
 
-    // Check for errors first
-    errType1 := &panosErrorResponseWithoutLine{}
-    err = xml.Unmarshal(body, errType1)
-    // At this point, we make use of the shared error error checking that exists
-    // between response types.  If the first response is not an error type, we
-    // don't have to check the others.  We can get some modest speed gains as
-    // a result.
-    if errType1.Failed() {
-        if err == nil && errType1.Error() != "" {
-            return body, PanosError{errType1.Error(), errType1.ResponseCode}
-        }
-        errType2 := panosErrorResponseWithLine{}
-        err = xml.Unmarshal(body, &errType2)
-        if err == nil && errType2.Error() != "" {
-            return body, PanosError{errType2.Error(), errType2.ResponseCode}
-        }
-        // Still an error, but some unknown format.
-        return body, fmt.Errorf("Unknown error format: %s", body)
-    }
+	// Check for errors first
+	errType1 := &panosErrorResponseWithoutLine{}
+	err = xml.Unmarshal(body, errType1)
+	// At this point, we make use of the shared error error checking that exists
+	// between response types.  If the first response is not an error type, we
+	// don't have to check the others.  We can get some modest speed gains as
+	// a result.
+	if errType1.Failed() {
+		if err == nil && errType1.Error() != "" {
+			return body, PanosError{errType1.Error(), errType1.ResponseCode}
+		}
+		errType2 := panosErrorResponseWithLine{}
+		err = xml.Unmarshal(body, &errType2)
+		if err == nil && errType2.Error() != "" {
+			return body, PanosError{errType2.Error(), errType2.ResponseCode}
+		}
+		// Still an error, but some unknown format.
+		return body, fmt.Errorf("Unknown error format: %s", body)
+	}
 
-    // Return the body string if we weren't given something to unmarshal into
-    if ans == nil {
-        return body, nil
-    }
+	// Return the body string if we weren't given something to unmarshal into
+	if ans == nil {
+		return body, nil
+	}
 
-    // Unmarshal using the struct passed in
-    err = xml.Unmarshal(body, ans)
-    if err != nil {
-        return body, fmt.Errorf("Error unmarshaling into provided interface: %s", err)
-    }
+	// Unmarshal using the struct passed in
+	err = xml.Unmarshal(body, ans)
+	if err != nil {
+		return body, fmt.Errorf("Error unmarshaling into provided interface: %s", err)
+	}
 
-    return body, nil
+	return body, nil
 }
 
 /*
@@ -1240,131 +1250,131 @@ Param `elms` is the ordered list of entities that should include both
 be found.
 */
 func (c *Client) PositionFirstEntity(mvt int, rel, ent string, path, elms []string) error {
-    // Sanity checks.
-    if rel == ent {
-        return fmt.Errorf("Can't position %q in relation to itself", rel)
-    } else if mvt < util.MoveSkip && mvt > util.MoveBottom {
-        return fmt.Errorf("Invalid position int given: %d", mvt)
-    } else if (mvt == util.MoveBefore || mvt == util.MoveDirectlyBefore || mvt == util.MoveAfter || mvt == util.MoveDirectlyAfter) && rel == "" {
-        return fmt.Errorf("Specify 'ref' in order to perform relative group positioning")
-    }
+	// Sanity checks.
+	if rel == ent {
+		return fmt.Errorf("Can't position %q in relation to itself", rel)
+	} else if mvt < util.MoveSkip && mvt > util.MoveBottom {
+		return fmt.Errorf("Invalid position int given: %d", mvt)
+	} else if (mvt == util.MoveBefore || mvt == util.MoveDirectlyBefore || mvt == util.MoveAfter || mvt == util.MoveDirectlyAfter) && rel == "" {
+		return fmt.Errorf("Specify 'ref' in order to perform relative group positioning")
+	}
 
-    var err error
-    fIdx := -1
-    oIdx := -1
+	var err error
+	fIdx := -1
+	oIdx := -1
 
-    switch mvt {
-    case util.MoveSkip:
-        return nil
-    case util.MoveTop:
-        _, em := c.Move(path, "top", "", nil, nil)
-        if em != nil && em.Error() != "already at the top" {
-            err = em
-        }
-    case util.MoveBottom:
-        _, em := c.Move(path, "bottom", "", nil, nil)
-        if em != nil && em.Error() != "already at the bottom" {
-            err = em
-        }
-    default:
-        // Find the indexes of the first rule and the ref rule.
-        for i, v := range elms {
-            if v == ent {
-                fIdx = i
-            } else if v == rel {
-                oIdx = i
-            }
-            if fIdx != -1 && oIdx != -1 {
-                break
-            }
-        }
+	switch mvt {
+	case util.MoveSkip:
+		return nil
+	case util.MoveTop:
+		_, em := c.Move(path, "top", "", nil, nil)
+		if em != nil && em.Error() != "already at the top" {
+			err = em
+		}
+	case util.MoveBottom:
+		_, em := c.Move(path, "bottom", "", nil, nil)
+		if em != nil && em.Error() != "already at the bottom" {
+			err = em
+		}
+	default:
+		// Find the indexes of the first rule and the ref rule.
+		for i, v := range elms {
+			if v == ent {
+				fIdx = i
+			} else if v == rel {
+				oIdx = i
+			}
+			if fIdx != -1 && oIdx != -1 {
+				break
+			}
+		}
 
-        // Sanity check: both rules should be present.
-        if fIdx == -1 {
-            return fmt.Errorf("Entity to be moved %q does not exist", ent)
-        } else if oIdx == -1 {
-            return fmt.Errorf("Reference entity %q does not exist", rel)
-        }
+		// Sanity check: both rules should be present.
+		if fIdx == -1 {
+			return fmt.Errorf("Entity to be moved %q does not exist", ent)
+		} else if oIdx == -1 {
+			return fmt.Errorf("Reference entity %q does not exist", rel)
+		}
 
-        // Move the first element, if needed.
-        if (mvt == util.MoveBefore && fIdx > oIdx) || (mvt == util.MoveDirectlyBefore && fIdx + 1 != oIdx) {
-            _, err = c.Move(path, "before", rel, nil, nil)
-        } else if (mvt == util.MoveAfter && fIdx < oIdx) || (mvt == util.MoveDirectlyAfter && fIdx != oIdx + 1) {
-            _, err = c.Move(path, "after", rel, nil, nil)
-        }
-    }
+		// Move the first element, if needed.
+		if (mvt == util.MoveBefore && fIdx > oIdx) || (mvt == util.MoveDirectlyBefore && fIdx+1 != oIdx) {
+			_, err = c.Move(path, "before", rel, nil, nil)
+		} else if (mvt == util.MoveAfter && fIdx < oIdx) || (mvt == util.MoveDirectlyAfter && fIdx != oIdx+1) {
+			_, err = c.Move(path, "after", rel, nil, nil)
+		}
+	}
 
-    return err
+	return err
 }
 
 /** Non-struct private functions **/
 
 func mergeUrlValues(data *url.Values, extras interface{}) error {
-    if extras == nil {
-        return nil
-    }
+	if extras == nil {
+		return nil
+	}
 
-    ev, ok := extras.(url.Values)
-    if !ok {
-        return fmt.Errorf("extras needs to be of type url.Values or nil")
-    }
+	ev, ok := extras.(url.Values)
+	if !ok {
+		return fmt.Errorf("extras needs to be of type url.Values or nil")
+	}
 
-    for key := range ev {
-        data.Set(key, ev.Get(key))
-    }
+	for key := range ev {
+		data.Set(key, ev.Get(key))
+	}
 
-    return nil
+	return nil
 }
 
 func addToData(key string, i interface{}, attemptMarshal bool, data *url.Values) error {
-    if i == nil {
-        return nil
-    }
+	if i == nil {
+		return nil
+	}
 
-    val, err := asString(i, attemptMarshal)
-    if err != nil {
-        return err
-    }
+	val, err := asString(i, attemptMarshal)
+	if err != nil {
+		return err
+	}
 
-    data.Set(key, val)
-    return nil
+	data.Set(key, val)
+	return nil
 }
 
 func asString(i interface{}, attemptMarshal bool) (string, error) {
-    switch val := i.(type) {
-    case string:
-        return val, nil
-    case fmt.Stringer:
-        return val.String(), nil
-    case nil:
-        return "", fmt.Errorf("nil encountered")
-    default:
-        if !attemptMarshal {
-            return "", fmt.Errorf("value must be string or fmt.Stringer")
-        }
+	switch val := i.(type) {
+	case string:
+		return val, nil
+	case fmt.Stringer:
+		return val.String(), nil
+	case nil:
+		return "", fmt.Errorf("nil encountered")
+	default:
+		if !attemptMarshal {
+			return "", fmt.Errorf("value must be string or fmt.Stringer")
+		}
 
-        rb, err := xml.Marshal(val)
-        if err != nil {
-            return "", err
-        }
-        return string(rb), nil
-    }
+		rb, err := xml.Marshal(val)
+		if err != nil {
+			return "", err
+		}
+		return string(rb), nil
+	}
 }
 
 // PanosError is the error struct returned from the Communicate method.
 type PanosError struct {
-    Msg string
-    Code int
+	Msg  string
+	Code int
 }
 
 // Error returns the error message.
 func (e PanosError) Error() string {
-    return e.Msg
+	return e.Msg
 }
 
 // ObjectNotFound returns true on missing object error.
 func (e PanosError) ObjectNotFound() bool {
-    return e.Code == 7
+	return e.Code == 7
 }
 
 /*
@@ -1375,54 +1385,54 @@ func (e PanosError) Code() int {
 */
 
 type panosStatus struct {
-    ResponseStatus string `xml:"status,attr"`
-    ResponseCode int `xml:"code,attr"`
+	ResponseStatus string `xml:"status,attr"`
+	ResponseCode   int    `xml:"code,attr"`
 }
 
 // Failed checks for a status of "failed" or "error".
 func (e panosStatus) Failed() bool {
-    if e.ResponseStatus == "failed" || e.ResponseStatus == "error" {
-        return true
-    } else if e.ResponseCode == 0 || e.ResponseCode == 19 || e.ResponseCode == 20 {
-        return false
-    } else {
-        return true
-    }
+	if e.ResponseStatus == "failed" || e.ResponseStatus == "error" {
+		return true
+	} else if e.ResponseCode == 0 || e.ResponseCode == 19 || e.ResponseCode == 20 {
+		return false
+	} else {
+		return true
+	}
 }
 
 func (e panosStatus) codeError() string {
-    switch e.ResponseCode {
-    case 1:
-        return "Unknown command"
-    case 2, 3, 4, 5, 11:
-        return fmt.Sprintf("Internal error (%d) encountered", e.ResponseCode)
-    case 6:
-        return "Bad Xpath"
-    case 7:
-        return "Object not found"
-    case 8:
-        return "Object not unique"
-    case 10:
-        return "Reference count not zero"
-    case 12:
-        return "Invalid object"
-    case 14:
-        return "Operation not possible"
-    case 15:
-        return "Operation denied"
-    case 16:
-        return "Unauthorized"
-    case 17:
-        return "Invalid command"
-    case 18:
-        return "Malformed command"
-    case 0, 19, 20:
-        return ""
-    case 22:
-        return "Session timed out"
-    default:
-        return fmt.Sprintf("(%d) Unknown failure code, operation failed", e.ResponseCode)
-    }
+	switch e.ResponseCode {
+	case 1:
+		return "Unknown command"
+	case 2, 3, 4, 5, 11:
+		return fmt.Sprintf("Internal error (%d) encountered", e.ResponseCode)
+	case 6:
+		return "Bad Xpath"
+	case 7:
+		return "Object not found"
+	case 8:
+		return "Object not unique"
+	case 10:
+		return "Reference count not zero"
+	case 12:
+		return "Invalid object"
+	case 14:
+		return "Operation not possible"
+	case 15:
+		return "Operation denied"
+	case 16:
+		return "Unauthorized"
+	case 17:
+		return "Invalid command"
+	case 18:
+		return "Malformed command"
+	case 0, 19, 20:
+		return ""
+	case 22:
+		return "Session timed out"
+	default:
+		return fmt.Sprintf("(%d) Unknown failure code, operation failed", e.ResponseCode)
+	}
 }
 
 // panosErrorResponseWithLine is one of a few known error formats that PAN-OS
@@ -1430,63 +1440,62 @@ func (e panosStatus) codeError() string {
 // the XML unmarshaler doesn't like a single struct to have overlapping
 // definitions (the msg>line part).
 type panosErrorResponseWithLine struct {
-    XMLName xml.Name `xml:"response"`
-    panosStatus
-    ResponseMsg string `xml:"msg>line"`
+	XMLName xml.Name `xml:"response"`
+	panosStatus
+	ResponseMsg string `xml:"msg>line"`
 }
 
 // Error retrieves the parsed error message.
 func (e panosErrorResponseWithLine) Error() string {
-    if e.ResponseMsg != "" {
-        return e.ResponseMsg
-    } else {
-        return e.codeError()
-    }
+	if e.ResponseMsg != "" {
+		return e.ResponseMsg
+	} else {
+		return e.codeError()
+	}
 }
-
 
 // panosErrorResponseWithoutLine is one of a few known error formats that PAN-OS
 // outputs.  It checks two locations that the error could be, and returns the
 // one that was discovered in its Error().
 type panosErrorResponseWithoutLine struct {
-    XMLName xml.Name `xml:"response"`
-    panosStatus
-    ResponseMsg1 string `xml:"result>msg"`
-    ResponseMsg2 string `xml:"msg"`
+	XMLName xml.Name `xml:"response"`
+	panosStatus
+	ResponseMsg1 string `xml:"result>msg"`
+	ResponseMsg2 string `xml:"msg"`
 }
 
 // Error retrieves the parsed error message.
 func (e panosErrorResponseWithoutLine) Error() string {
-    if e.ResponseMsg1 != "" {
-        return e.ResponseMsg1
-    } else {
-        return e.ResponseMsg2
-    }
+	if e.ResponseMsg1 != "" {
+		return e.ResponseMsg1
+	} else {
+		return e.ResponseMsg2
+	}
 }
 
 // vis is a vsys import struct.
 type vis struct {
-    XMLName xml.Name
-    Text string `xml:",chardata"`
+	XMLName xml.Name
+	Text    string `xml:",chardata"`
 }
 
 type configLocks struct {
-    Locks []util.Lock `xml:"result>config-locks>entry"`
+	Locks []util.Lock `xml:"result>config-locks>entry"`
 }
 
 type commitLocks struct {
-    Locks []util.Lock `xml:"result>commit-locks>entry"`
+	Locks []util.Lock `xml:"result>commit-locks>entry"`
 }
 
 type baseCommit struct {
-    XMLName xml.Name `xml:"commit"`
-    Description string `xml:"description,omitempty"`
-    Partial *baseCommitPartial `xml:"partial"`
-    Force interface{} `xml:"force"`
+	XMLName     xml.Name           `xml:"commit"`
+	Description string             `xml:"description,omitempty"`
+	Partial     *baseCommitPartial `xml:"partial"`
+	Force       interface{}        `xml:"force"`
 }
 
 type baseCommitPartial struct {
-    Dan string `xml:"device-and-network,omitempty"`
-    Pao string `xml:"policy-and-objects,omitempty"`
-    Admin *util.MemberType `xml:"admin"`
+	Dan   string           `xml:"device-and-network,omitempty"`
+	Pao   string           `xml:"policy-and-objects,omitempty"`
+	Admin *util.MemberType `xml:"admin"`
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/PaloAltoNetworks/pango
 
-go 1.12
+go 1.13

--- a/netw/routing/route/static/ipv4/entry.go
+++ b/netw/routing/route/static/ipv4/entry.go
@@ -1,324 +1,356 @@
 package ipv4
 
 import (
-    "encoding/xml"
+	"encoding/xml"
 )
 
 const (
-    NextHopDiscard = "discard"
-    NextHopIpAddress = "ip-address"
-    NextHopNextVr = "next-vr"
+	NextHopDiscard   = "discard"
+	NextHopIpAddress = "ip-address"
+	NextHopNextVr    = "next-vr"
 )
 
 const (
-    RouteTableNoInstall = "no install"
-    RouteTableUnicast = "unicast"
-    RouteTableMulticast = "multicast"
-    RouteTableBoth = "both"
+	RouteTableNoInstall = "no install"
+	RouteTableUnicast   = "unicast"
+	RouteTableMulticast = "multicast"
+	RouteTableBoth      = "both"
 )
 
 // Entry is a normalized, version independent representation of an IPv4
 // static route.
 type Entry struct {
-    Name string
-    Destination string
-    Interface string
-    Type string
-    NextHop string
-    AdminDistance int
-    Metric int
-    RouteTable string
-    BfdProfile string
+	Name          string
+	Destination   string
+	Interface     string
+	Type          string
+	NextHop       string
+	AdminDistance int
+	Metric        int
+	RouteTable    string
+	BfdProfile    string
 }
 
 func (o *Entry) Copy(s Entry) {
-    o.Destination = s.Destination
-    o.Interface = s.Interface
-    o.Type = s.Type
-    o.NextHop = s.NextHop
-    o.AdminDistance = s.AdminDistance
-    o.Metric = s.Metric
-    o.RouteTable = s.RouteTable
-    o.BfdProfile = s.BfdProfile
+	o.Destination = s.Destination
+	o.Interface = s.Interface
+	o.Type = s.Type
+	o.NextHop = s.NextHop
+	o.AdminDistance = s.AdminDistance
+	o.Metric = s.Metric
+	o.RouteTable = s.RouteTable
+	o.BfdProfile = s.BfdProfile
 }
 
 /** Structs / functions for this namespace. **/
 
 type normalizer interface {
-    Normalize() Entry
+	Normalize() Entry
 }
 
 type container_v1 struct {
-    Answer entry_v1 `xml:"result>entry"`
+	Answer entry_v1 `xml:"result>entry"`
 }
 
 func (o *container_v1) Normalize() Entry {
-    ans := Entry{
-        Name: o.Answer.Name,
-        Destination: o.Answer.Destination,
-        Interface: o.Answer.Interface,
-        AdminDistance: o.Answer.AdminDistance,
-        Metric: o.Answer.Metric,
-    }
+	ans := Entry{
+		Name:          o.Answer.Name,
+		Destination:   o.Answer.Destination,
+		Interface:     o.Answer.Interface,
+		AdminDistance: o.Answer.AdminDistance,
+		Metric:        o.Answer.Metric,
+	}
 
-    if o.Answer.NextHop == nil {
-        ans.Type = ""
-    } else if o.Answer.NextHop.Discard != nil {
-        ans.Type = NextHopDiscard
-    } else if o.Answer.NextHop.IpAddress != nil {
-        ans.Type = NextHopIpAddress
-        ans.NextHop = *o.Answer.NextHop.IpAddress
-    } else if o.Answer.NextHop.NextVr != nil {
-        ans.Type = NextHopNextVr
-        ans.NextHop = *o.Answer.NextHop.NextVr
-    }
+	if o.Answer.NextHop == nil {
+		ans.Type = ""
+	} else if o.Answer.NextHop.Discard != nil {
+		ans.Type = NextHopDiscard
+	} else if o.Answer.NextHop.IpAddress != nil {
+		ans.Type = NextHopIpAddress
+		ans.NextHop = *o.Answer.NextHop.IpAddress
+	} else if o.Answer.NextHop.NextVr != nil {
+		ans.Type = NextHopNextVr
+		ans.NextHop = *o.Answer.NextHop.NextVr
+	}
 
-    if o.Answer.Option != nil && o.Answer.Option.NoInstall != nil {
-        ans.RouteTable = RouteTableNoInstall
-    }
+	if o.Answer.Option != nil && o.Answer.Option.NoInstall != nil {
+		ans.RouteTable = RouteTableNoInstall
+	}
 
-    return ans
+	return ans
 }
 
 type entry_v1 struct {
-    XMLName xml.Name `xml:"entry"`
-    Name string `xml:"name,attr"`
-    Destination string `xml:"destination"`
-    Interface string `xml:"interface,omitempty"`
-    NextHop *nextHop `xml:"nexthop"`
-    AdminDistance int `xml:"admin-dist,omitempty"`
-    Metric int `xml:"metric,omitempty"`
-    Option *rtOption_v1 `xml:"option"`
+	XMLName       xml.Name     `xml:"entry"`
+	Name          string       `xml:"name,attr"`
+	Destination   string       `xml:"destination"`
+	Interface     string       `xml:"interface,omitempty"`
+	NextHop       *nextHop     `xml:"nexthop"`
+	AdminDistance int          `xml:"admin-dist,omitempty"`
+	Metric        int          `xml:"metric,omitempty"`
+	Option        *rtOption_v1 `xml:"option"`
 }
 
 type nextHop struct {
-    Discard *string `xml:"discard"`
-    IpAddress *string `xml:"ip-address"`
-    NextVr *string `xml:"next-vr"`
+	Discard   *string `xml:"discard"`
+	IpAddress *string `xml:"ip-address"`
+	NextVr    *string `xml:"next-vr"`
 }
 
 type rtOption_v1 struct {
-    NoInstall *string `xml:"no-install"`
+	NoInstall *string `xml:"no-install"`
 }
 
 func specify_v1(e Entry) interface{} {
-    ans := entry_v1{
-        Name: e.Name,
-        Destination: e.Destination,
-        Interface: e.Interface,
-        AdminDistance: e.AdminDistance,
-        Metric: e.Metric,
-    }
+	ans := entry_v1{
+		Name:          e.Name,
+		Destination:   e.Destination,
+		Interface:     e.Interface,
+		AdminDistance: e.AdminDistance,
+		Metric:        e.Metric,
+	}
 
-    switch e.Type {
-    case NextHopDiscard:
-        var sp string
-        ans.NextHop = &nextHop{Discard: &sp}
-    case NextHopIpAddress:
-        sp := e.NextHop
-        ans.NextHop = &nextHop{IpAddress: &sp}
-    case NextHopNextVr:
-        sp := e.NextHop
-        ans.NextHop = &nextHop{NextVr: &sp}
-    }
+	switch e.Type {
+	case NextHopDiscard:
+		var sp string
+		ans.NextHop = &nextHop{Discard: &sp}
+	case NextHopIpAddress:
+		sp := e.NextHop
+		ans.NextHop = &nextHop{IpAddress: &sp}
+	case NextHopNextVr:
+		sp := e.NextHop
+		ans.NextHop = &nextHop{NextVr: &sp}
+	}
 
-    if e.RouteTable == RouteTableNoInstall {
-        sp := ""
-        ans.Option = &rtOption_v1{NoInstall: &sp}
-    }
+	if e.RouteTable == RouteTableNoInstall {
+		sp := ""
+		ans.Option = &rtOption_v1{NoInstall: &sp}
+	}
 
-    return ans
+	return ans
 }
 
 // PAN-OS 7.1, adds BfdProfile
 type container_v2 struct {
-    Answer entry_v2 `xml:"result>entry"`
+	Answer entry_v2 `xml:"result>entry"`
 }
 
 func (o *container_v2) Normalize() Entry {
-    ans := Entry{
-        Name: o.Answer.Name,
-        Destination: o.Answer.Destination,
-        Interface: o.Answer.Interface,
-        AdminDistance: o.Answer.AdminDistance,
-        Metric: o.Answer.Metric,
-    }
+	ans := Entry{
+		Name:          o.Answer.Name,
+		Destination:   o.Answer.Destination,
+		Interface:     o.Answer.Interface,
+		AdminDistance: o.Answer.AdminDistance,
+		Metric:        o.Answer.Metric,
+	}
 
-    if o.Answer.NextHop == nil {
-        ans.Type = ""
-    } else if o.Answer.NextHop.Discard != nil {
-        ans.Type = NextHopDiscard
-    } else if o.Answer.NextHop.IpAddress != nil {
-        ans.Type = NextHopIpAddress
-        ans.NextHop = *o.Answer.NextHop.IpAddress
-    } else if o.Answer.NextHop.NextVr != nil {
-        ans.Type = NextHopNextVr
-        ans.NextHop = *o.Answer.NextHop.NextVr
-    }
+	if o.Answer.NextHop == nil {
+		ans.Type = ""
+	} else if o.Answer.NextHop.Discard != nil {
+		ans.Type = NextHopDiscard
+	} else if o.Answer.NextHop.IpAddress != nil {
+		ans.Type = NextHopIpAddress
+		ans.NextHop = *o.Answer.NextHop.IpAddress
+	} else if o.Answer.NextHop.NextVr != nil {
+		ans.Type = NextHopNextVr
+		ans.NextHop = *o.Answer.NextHop.NextVr
+	}
 
-    if o.Answer.Option != nil && o.Answer.Option.NoInstall != nil {
-        ans.RouteTable = RouteTableNoInstall
-    }
+	if o.Answer.Option != nil && o.Answer.Option.NoInstall != nil {
+		ans.RouteTable = RouteTableNoInstall
+	}
 
-    if o.Answer.Bfd != nil {
-        ans.BfdProfile = o.Answer.Bfd.Profile
-    }
+	if o.Answer.Bfd != nil {
+		ans.BfdProfile = o.Answer.Bfd.Profile
+	}
 
-    return ans
+	return ans
 }
 
 type entry_v2 struct {
-    XMLName xml.Name `xml:"entry"`
-    Name string `xml:"name,attr"`
-    Destination string `xml:"destination"`
-    Interface string `xml:"interface,omitempty"`
-    NextHop *nextHop `xml:"nexthop"`
-    AdminDistance int `xml:"admin-dist,omitempty"`
-    Metric int `xml:"metric,omitempty"`
-    Option *rtOption_v1 `xml:"option"`
-    Bfd *bfd `xml:"bfd"`
+	XMLName       xml.Name     `xml:"entry"`
+	Name          string       `xml:"name,attr"`
+	Destination   string       `xml:"destination"`
+	Interface     string       `xml:"interface,omitempty"`
+	NextHop       *nextHop     `xml:"nexthop"`
+	AdminDistance int          `xml:"admin-dist,omitempty"`
+	Metric        int          `xml:"metric,omitempty"`
+	Option        *rtOption_v1 `xml:"option"`
+	Bfd           *bfd         `xml:"bfd"`
 }
 
 type bfd struct {
-    Profile string `xml:"profile"`
+	Profile string `xml:"profile"`
 }
 
 func specify_v2(e Entry) interface{} {
-    ans := entry_v2{
-        Name: e.Name,
-        Destination: e.Destination,
-        Interface: e.Interface,
-        AdminDistance: e.AdminDistance,
-        Metric: e.Metric,
-    }
+	ans := entry_v2{
+		Name:          e.Name,
+		Destination:   e.Destination,
+		Interface:     e.Interface,
+		AdminDistance: e.AdminDistance,
+		Metric:        e.Metric,
+	}
 
-    switch e.Type {
-    case NextHopDiscard:
-        var sp string
-        ans.NextHop = &nextHop{Discard: &sp}
-    case NextHopIpAddress:
-        sp := e.NextHop
-        ans.NextHop = &nextHop{IpAddress: &sp}
-    case NextHopNextVr:
-        sp := e.NextHop
-        ans.NextHop = &nextHop{NextVr: &sp}
-    }
+	switch e.Type {
+	case NextHopDiscard:
+		var sp string
+		ans.NextHop = &nextHop{Discard: &sp}
+	case NextHopIpAddress:
+		sp := e.NextHop
+		ans.NextHop = &nextHop{IpAddress: &sp}
+	case NextHopNextVr:
+		sp := e.NextHop
+		ans.NextHop = &nextHop{NextVr: &sp}
+	}
 
-    if e.RouteTable == RouteTableNoInstall {
-        sp := ""
-        ans.Option = &rtOption_v1{NoInstall: &sp}
-    }
+	if e.RouteTable == RouteTableNoInstall {
+		sp := ""
+		ans.Option = &rtOption_v1{NoInstall: &sp}
+	}
 
-    if e.BfdProfile != "" {
-        ans.Bfd = &bfd{Profile: e.BfdProfile}
-    }
+	if e.BfdProfile != "" {
+		ans.Bfd = &bfd{Profile: e.BfdProfile}
+	}
 
-    return ans
+	return ans
 }
 
 // PAN-OS 8.0, new routing table options
 type container_v3 struct {
-    Answer entry_v3 `xml:"result>entry"`
+	Answer entry_v3 `xml:"result>entry"`
 }
 
 func (o *container_v3) Normalize() Entry {
-    ans := Entry{
-        Name: o.Answer.Name,
-        Destination: o.Answer.Destination,
-        Interface: o.Answer.Interface,
-        AdminDistance: o.Answer.AdminDistance,
-        Metric: o.Answer.Metric,
-    }
+	ans := Entry{
+		Name:          o.Answer.Name,
+		Destination:   o.Answer.Destination,
+		Interface:     o.Answer.Interface,
+		AdminDistance: o.Answer.AdminDistance,
+		Metric:        o.Answer.Metric,
+	}
 
-    if o.Answer.NextHop == nil {
-        ans.Type = ""
-    } else if o.Answer.NextHop.Discard != nil {
-        ans.Type = NextHopDiscard
-    } else if o.Answer.NextHop.IpAddress != nil {
-        ans.Type = NextHopIpAddress
-        ans.NextHop = *o.Answer.NextHop.IpAddress
-    } else if o.Answer.NextHop.NextVr != nil {
-        ans.Type = NextHopNextVr
-        ans.NextHop = *o.Answer.NextHop.NextVr
-    }
+	if o.Answer.NextHop == nil {
+		ans.Type = ""
+	} else if o.Answer.NextHop.Discard != nil {
+		ans.Type = NextHopDiscard
+	} else if o.Answer.NextHop.IpAddress != nil {
+		ans.Type = NextHopIpAddress
+		ans.NextHop = *o.Answer.NextHop.IpAddress
+	} else if o.Answer.NextHop.NextVr != nil {
+		ans.Type = NextHopNextVr
+		ans.NextHop = *o.Answer.NextHop.NextVr
+	}
 
-    if o.Answer.Option != nil {
-        if o.Answer.Option.Unicast != nil {
-            ans.RouteTable = RouteTableUnicast
-        } else if o.Answer.Option.Multicast != nil {
-            ans.RouteTable = RouteTableMulticast
-        } else if o.Answer.Option.Both != nil {
-            ans.RouteTable = RouteTableBoth
-        } else if o.Answer.Option.NoInstall != nil {
-            ans.RouteTable = RouteTableNoInstall
-        }
-    }
+	if o.Answer.Option != nil {
+		if o.Answer.Option.Unicast != nil {
+			ans.RouteTable = RouteTableUnicast
+		} else if o.Answer.Option.Multicast != nil {
+			ans.RouteTable = RouteTableMulticast
+		} else if o.Answer.Option.Both != nil {
+			ans.RouteTable = RouteTableBoth
+		} else if o.Answer.Option.NoInstall != nil {
+			ans.RouteTable = RouteTableNoInstall
+		}
+	}
 
-    if o.Answer.Bfd != nil {
-        ans.BfdProfile = o.Answer.Bfd.Profile
-    }
+	if o.Answer.Bfd != nil {
+		ans.BfdProfile = o.Answer.Bfd.Profile
+	}
 
-    return ans
+	return ans
 }
 
 type entry_v3 struct {
-    XMLName xml.Name `xml:"entry"`
-    Name string `xml:"name,attr"`
-    Destination string `xml:"destination"`
-    Interface string `xml:"interface,omitempty"`
-    NextHop *nextHop `xml:"nexthop"`
-    AdminDistance int `xml:"admin-dist,omitempty"`
-    Metric int `xml:"metric,omitempty"`
-    Option *rtOption_v2 `xml:"route-table"`
-    Bfd *bfd `xml:"bfd"`
+	XMLName       xml.Name     `xml:"entry"`
+	Name          string       `xml:"name,attr"`
+	Destination   string       `xml:"destination"`
+	Interface     string       `xml:"interface,omitempty"`
+	NextHop       *nextHop     `xml:"nexthop"`
+	AdminDistance int          `xml:"admin-dist,omitempty"`
+	Metric        int          `xml:"metric,omitempty"`
+	Option        *rtOption_v2 `xml:"route-table"`
+	Bfd           *bfd         `xml:"bfd"`
 }
 
 type rtOption_v2 struct {
-    Unicast *string `xml:"unicast"`
-    Multicast *string `xml:"multicast"`
-    Both *string `xml:"both"`
-    NoInstall *string `xml:"no-install"`
+	Unicast   *string `xml:"unicast"`
+	Multicast *string `xml:"multicast"`
+	Both      *string `xml:"both"`
+	NoInstall *string `xml:"no-install"`
 }
 
 func specify_v3(e Entry) interface{} {
-    ans := entry_v3{
-        Name: e.Name,
-        Destination: e.Destination,
-        Interface: e.Interface,
-        AdminDistance: e.AdminDistance,
-        Metric: e.Metric,
-    }
+	ans := entry_v3{
+		Name:          e.Name,
+		Destination:   e.Destination,
+		Interface:     e.Interface,
+		AdminDistance: e.AdminDistance,
+		Metric:        e.Metric,
+	}
 
-    switch e.Type {
-    case NextHopDiscard:
-        var sp string
-        ans.NextHop = &nextHop{Discard: &sp}
-    case NextHopIpAddress:
-        sp := e.NextHop
-        ans.NextHop = &nextHop{IpAddress: &sp}
-    case NextHopNextVr:
-        sp := e.NextHop
-        ans.NextHop = &nextHop{NextVr: &sp}
-    }
+	switch e.Type {
+	case NextHopDiscard:
+		var sp string
+		ans.NextHop = &nextHop{Discard: &sp}
+	case NextHopIpAddress:
+		sp := e.NextHop
+		ans.NextHop = &nextHop{IpAddress: &sp}
+	case NextHopNextVr:
+		sp := e.NextHop
+		ans.NextHop = &nextHop{NextVr: &sp}
+	}
 
-    switch e.RouteTable {
-    case RouteTableUnicast:
-        sp := ""
-        ans.Option = &rtOption_v2{Unicast: &sp}
-    case RouteTableMulticast:
-        sp := ""
-        ans.Option = &rtOption_v2{Multicast: &sp}
-    case RouteTableBoth:
-        sp := ""
-        ans.Option = &rtOption_v2{Both: &sp}
-    case RouteTableNoInstall:
-        sp := ""
-        ans.Option = &rtOption_v2{NoInstall: &sp}
-    }
+	switch e.RouteTable {
+	case RouteTableUnicast:
+		sp := ""
+		ans.Option = &rtOption_v2{Unicast: &sp}
+	case RouteTableMulticast:
+		sp := ""
+		ans.Option = &rtOption_v2{Multicast: &sp}
+	case RouteTableBoth:
+		sp := ""
+		ans.Option = &rtOption_v2{Both: &sp}
+	case RouteTableNoInstall:
+		sp := ""
+		ans.Option = &rtOption_v2{NoInstall: &sp}
+	}
 
-    if e.BfdProfile != "" {
-        ans.Bfd = &bfd{Profile: e.BfdProfile}
-    }
+	if e.BfdProfile != "" {
+		ans.Bfd = &bfd{Profile: e.BfdProfile}
+	}
 
-    return ans
+	return ans
+}
+
+//EntryContainerMulti container for full list of routes
+type EntryContainerMulti struct {
+	Entries []Entry `xml:"response>result>route>entry"`
+}
+
+//UnmarshalXML parses raw result for the address object xml tree
+func (e *EntryContainerMulti) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for {
+		token, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch childToken := token.(type) {
+		case xml.StartElement:
+			switch childToken.Name.Local {
+			case "entry":
+				entry := entry_v2{}
+				err = d.DecodeElement(&entry, &childToken)
+				if err != nil {
+					return err
+				}
+				containerized := container_v2{entry}
+				e.Entries = append(e.Entries, containerized.Normalize())
+			}
+		case xml.EndElement:
+			if childToken == start.End() {
+				return nil
+			}
+		}
+	}
 }

--- a/objs/addr/entry.go
+++ b/objs/addr/entry.go
@@ -1,150 +1,182 @@
 package addr
 
 import (
-    "encoding/xml"
+	"encoding/xml"
 
-    "github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/util"
 )
 
 // Entry is a normalized, version independent representation of an address
 // object.
 type Entry struct {
-    Name string
-    Value string
-    Type string
-    Description string
-    Tags []string // ordered
+	Name        string
+	Value       string
+	Type        string
+	Description string
+	Tags        []string // ordered
 }
 
 // Copy copies the information from source Entry `s` to this object.  As the
 // Name field relates to the XPATH of this object, this field is not copied.
 func (o *Entry) Copy(s Entry) {
-    o.Value = s.Value
-    o.Type = s.Type
-    o.Description = s.Description
-    o.Tags = s.Tags
+	o.Value = s.Value
+	o.Type = s.Type
+	o.Description = s.Description
+	o.Tags = s.Tags
 }
 
 /** Structs / functions for normalization. **/
 
 type normalizer interface {
-    Normalize() Entry
+	Normalize() Entry
 }
 
 type container_v1 struct {
-    Answer entry_v1 `xml:"result>entry"`
+	Answer entry_v1 `xml:"result>entry"`
 }
 
 func (o *container_v1) Normalize() Entry {
-    ans := Entry{
-        Name: o.Answer.Name,
-        Description: o.Answer.Description,
-        Tags: util.MemToStr(o.Answer.Tags),
-    }
-    switch {
-    case o.Answer.IpNetmask != nil:
-        ans.Type = IpNetmask
-        ans.Value = o.Answer.IpNetmask.Value
-    case o.Answer.IpRange != nil:
-        ans.Type = IpRange
-        ans.Value = o.Answer.IpRange.Value
-    case o.Answer.Fqdn != nil:
-        ans.Type = Fqdn
-        ans.Value = o.Answer.Fqdn.Value
-    }
+	ans := Entry{
+		Name:        o.Answer.Name,
+		Description: o.Answer.Description,
+		Tags:        util.MemToStr(o.Answer.Tags),
+	}
+	switch {
+	case o.Answer.IpNetmask != nil:
+		ans.Type = IpNetmask
+		ans.Value = o.Answer.IpNetmask.Value
+	case o.Answer.IpRange != nil:
+		ans.Type = IpRange
+		ans.Value = o.Answer.IpRange.Value
+	case o.Answer.Fqdn != nil:
+		ans.Type = Fqdn
+		ans.Value = o.Answer.Fqdn.Value
+	}
 
-    return ans
+	return ans
 }
 
 type container_v2 struct {
-    Answer entry_v2 `xml:"result>entry"`
+	Answer entry_v2 `xml:"result>entry"`
 }
 
 func (o *container_v2) Normalize() Entry {
-    ans := Entry{
-        Name: o.Answer.Name,
-        Description: o.Answer.Description,
-        Tags: util.MemToStr(o.Answer.Tags),
-    }
-    switch {
-    case o.Answer.IpNetmask != nil:
-        ans.Type = IpNetmask
-        ans.Value = o.Answer.IpNetmask.Value
-    case o.Answer.IpRange != nil:
-        ans.Type = IpRange
-        ans.Value = o.Answer.IpRange.Value
-    case o.Answer.Fqdn != nil:
-        ans.Type = Fqdn
-        ans.Value = o.Answer.Fqdn.Value
-    case o.Answer.IpWildcard != nil:
-        ans.Type = IpWildcard
-        ans.Value = o.Answer.IpWildcard.Value
-    }
+	ans := Entry{
+		Name:        o.Answer.Name,
+		Description: o.Answer.Description,
+		Tags:        util.MemToStr(o.Answer.Tags),
+	}
+	switch {
+	case o.Answer.IpNetmask != nil:
+		ans.Type = IpNetmask
+		ans.Value = o.Answer.IpNetmask.Value
+	case o.Answer.IpRange != nil:
+		ans.Type = IpRange
+		ans.Value = o.Answer.IpRange.Value
+	case o.Answer.Fqdn != nil:
+		ans.Type = Fqdn
+		ans.Value = o.Answer.Fqdn.Value
+	case o.Answer.IpWildcard != nil:
+		ans.Type = IpWildcard
+		ans.Value = o.Answer.IpWildcard.Value
+	}
 
-    return ans
+	return ans
 }
 
 type entry_v1 struct {
-    XMLName xml.Name `xml:"entry"`
-    Name string `xml:"name,attr"`
-    IpNetmask *valType `xml:"ip-netmask"`
-    IpRange *valType `xml:"ip-range"`
-    Fqdn *valType `xml:"fqdn"`
-    Description string `xml:"description"`
-    Tags *util.MemberType `xml:"tag"`
+	XMLName     xml.Name         `xml:"entry"`
+	Name        string           `xml:"name,attr"`
+	IpNetmask   *valType         `xml:"ip-netmask"`
+	IpRange     *valType         `xml:"ip-range"`
+	Fqdn        *valType         `xml:"fqdn"`
+	Description string           `xml:"description"`
+	Tags        *util.MemberType `xml:"tag"`
 }
 
 type valType struct {
-    Value string `xml:",chardata"`
+	Value string `xml:",chardata"`
 }
 
 func specify_v1(e Entry) interface{} {
-    ans := entry_v1{
-        Name: e.Name,
-        Description: e.Description,
-        Tags: util.StrToMem(e.Tags),
-    }
-    vt := &valType{e.Value}
-    switch e.Type {
-    case IpNetmask:
-        ans.IpNetmask = vt
-    case IpRange:
-        ans.IpRange = vt
-    case Fqdn:
-        ans.Fqdn = vt
-    }
+	ans := entry_v1{
+		Name:        e.Name,
+		Description: e.Description,
+		Tags:        util.StrToMem(e.Tags),
+	}
+	vt := &valType{e.Value}
+	switch e.Type {
+	case IpNetmask:
+		ans.IpNetmask = vt
+	case IpRange:
+		ans.IpRange = vt
+	case Fqdn:
+		ans.Fqdn = vt
+	}
 
-    return ans
+	return ans
 }
 
 type entry_v2 struct {
-    XMLName xml.Name `xml:"entry"`
-    Name string `xml:"name,attr"`
-    IpNetmask *valType `xml:"ip-netmask"`
-    IpRange *valType `xml:"ip-range"`
-    Fqdn *valType `xml:"fqdn"`
-    IpWildcard *valType `xml:"ip-wildcard"`
-    Description string `xml:"description"`
-    Tags *util.MemberType `xml:"tag"`
+	XMLName     xml.Name         `xml:"entry"`
+	Name        string           `xml:"name,attr"`
+	IpNetmask   *valType         `xml:"ip-netmask"`
+	IpRange     *valType         `xml:"ip-range"`
+	Fqdn        *valType         `xml:"fqdn"`
+	IpWildcard  *valType         `xml:"ip-wildcard"`
+	Description string           `xml:"description"`
+	Tags        *util.MemberType `xml:"tag"`
 }
 
 func specify_v2(e Entry) interface{} {
-    ans := entry_v2{
-        Name: e.Name,
-        Description: e.Description,
-        Tags: util.StrToMem(e.Tags),
-    }
-    vt := &valType{e.Value}
-    switch e.Type {
-    case IpNetmask:
-        ans.IpNetmask = vt
-    case IpRange:
-        ans.IpRange = vt
-    case Fqdn:
-        ans.Fqdn = vt
-    case IpWildcard:
-        ans.IpWildcard = vt
-    }
+	ans := entry_v2{
+		Name:        e.Name,
+		Description: e.Description,
+		Tags:        util.StrToMem(e.Tags),
+	}
+	vt := &valType{e.Value}
+	switch e.Type {
+	case IpNetmask:
+		ans.IpNetmask = vt
+	case IpRange:
+		ans.IpRange = vt
+	case Fqdn:
+		ans.Fqdn = vt
+	case IpWildcard:
+		ans.IpWildcard = vt
+	}
 
-    return ans
+	return ans
+}
+
+//EntryContainerMulti container for full list of address objects
+type EntryContainerMulti struct {
+	Entries []Entry `xml:"response>result>address>entry"`
+}
+
+//UnmarshalXML parses raw result for the address object xml tree
+func (e *EntryContainerMulti) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for {
+		token, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch childToken := token.(type) {
+		case xml.StartElement:
+			switch childToken.Name.Local {
+			case "entry":
+				entry := entry_v2{}
+				err = d.DecodeElement(&entry, &childToken)
+				if err != nil {
+					return err
+				}
+				containerized := container_v2{entry}
+				e.Entries = append(e.Entries, containerized.Normalize())
+			}
+		case xml.EndElement:
+			if childToken == start.End() {
+				return nil
+			}
+		}
+	}
 }

--- a/objs/addr/fw.go
+++ b/objs/addr/fw.go
@@ -1,170 +1,194 @@
 package addr
 
 import (
-    "fmt"
-    "encoding/xml"
+	"encoding/xml"
+	"fmt"
 
-    "github.com/PaloAltoNetworks/pango/util"
-    "github.com/PaloAltoNetworks/pango/version"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
 )
 
 // FwAddr is a namespace struct, included as part of pango.Firewall.
 type FwAddr struct {
-    con util.XapiClient
+	con util.XapiClient
 }
 
 // Initialize is invoked when Initialize on the pango.Client is called.
 func (c *FwAddr) Initialize(con util.XapiClient) {
-    c.con = con
+	c.con = con
 }
 
-// GetList performs GET to retrieve a list of address objects.
+// GetList performs GET to retrieve a list of address object names.
 func (c *FwAddr) GetList(vsys string) ([]string, error) {
-    c.con.LogQuery("(get) list of address objects")
-    path := c.xpath(vsys, nil)
-    return c.con.EntryListUsing(c.con.Get, path[:len(path) - 1])
+	c.con.LogQuery("(get) list of address objects")
+	path := c.xpath(vsys, nil)
+	return c.con.EntryListUsing(c.con.Get, path[:len(path)-1])
 }
 
-// ShowList performs SHOW to retrieve a list of address objects.
+// GetFullList performs GET to retreive a list of address objects.
+func (c *FwAddr) GetFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(get) list of address objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
+}
+
+// ShowList performs SHOW to retrieve a list of address object names.
 func (c *FwAddr) ShowList(vsys string) ([]string, error) {
-    c.con.LogQuery("(show) list of address objects")
-    path := c.xpath(vsys, nil)
-    return c.con.EntryListUsing(c.con.Show, path[:len(path) - 1])
+	c.con.LogQuery("(show) list of address objects")
+	path := c.xpath(vsys, nil)
+	return c.con.EntryListUsing(c.con.Show, path[:len(path)-1])
+}
+
+// ShowFullList performs SHOW to retreive a list of address objects.
+func (c *FwAddr) ShowFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(show) list of address objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Show, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // Get performs GET to retrieve information for the given address object.
 func (c *FwAddr) Get(vsys, name string) (Entry, error) {
-    c.con.LogQuery("(get) address object %q", name)
-    return c.details(c.con.Get, vsys, name)
+	c.con.LogQuery("(get) address object %q", name)
+	return c.details(c.con.Get, vsys, name)
 }
 
 // Get performs SHOW to retrieve information for the given address object.
 func (c *FwAddr) Show(vsys, name string) (Entry, error) {
-    c.con.LogQuery("(show) address object %q", name)
-    return c.details(c.con.Show, vsys, name)
+	c.con.LogQuery("(show) address object %q", name)
+	return c.details(c.con.Show, vsys, name)
 }
 
 // Set performs SET to create / update one or more address objects.
 func (c *FwAddr) Set(vsys string, e ...Entry) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    _, fn := c.versioning()
-    names := make([]string, len(e))
+	_, fn := c.versioning()
+	names := make([]string, len(e))
 
-    // Build up the struct with the given configs.
-    d := util.BulkElement{XMLName: xml.Name{Local: "address"}}
-    for i := range e {
-        d.Data = append(d.Data, fn(e[i]))
-        names[i] = e[i].Name
-    }
-    c.con.LogAction("(set) address objects: %v", names)
+	// Build up the struct with the given configs.
+	d := util.BulkElement{XMLName: xml.Name{Local: "address"}}
+	for i := range e {
+		d.Data = append(d.Data, fn(e[i]))
+		names[i] = e[i].Name
+	}
+	c.con.LogAction("(set) address objects: %v", names)
 
-    // Set xpath.
-    path := c.xpath(vsys, names)
-    if len(e) == 1 {
-        path = path[:len(path) - 1]
-    } else {
-        path = path[:len(path) - 2]
-    }
+	// Set xpath.
+	path := c.xpath(vsys, names)
+	if len(e) == 1 {
+		path = path[:len(path)-1]
+	} else {
+		path = path[:len(path)-2]
+	}
 
-    // Create the objects.
-    _, err = c.con.Set(path, d.Config(), nil, nil)
-    return err
+	// Create the objects.
+	_, err = c.con.Set(path, d.Config(), nil, nil)
+	return err
 }
 
 // Edit performs EDIT to create / update an address object.
 func (c *FwAddr) Edit(vsys string, e Entry) error {
-    var err error
+	var err error
 
-    _, fn := c.versioning()
+	_, fn := c.versioning()
 
-    c.con.LogAction("(edit) address object %q", e.Name)
+	c.con.LogAction("(edit) address object %q", e.Name)
 
-    // Set xpath.
-    path := c.xpath(vsys, []string{e.Name})
+	// Set xpath.
+	path := c.xpath(vsys, []string{e.Name})
 
-    // Create the objects.
-    _, err = c.con.Edit(path, fn(e), nil, nil)
-    return err
+	// Create the objects.
+	_, err = c.con.Edit(path, fn(e), nil, nil)
+	return err
 }
 
 // Delete removes the given address objects from the firewall.
 //
 // Address objects can be either a string or an Entry object.
 func (c *FwAddr) Delete(vsys string, e ...interface{}) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    names := make([]string, len(e))
-    for i := range e {
-        switch v := e[i].(type) {
-        case string:
-            names[i] = v
-        case Entry:
-            names[i] = v.Name
-        default:
-            return fmt.Errorf("Unsupported type to delete: %s", v)
-        }
-    }
-    c.con.LogAction("(delete) address objects: %v", names)
+	names := make([]string, len(e))
+	for i := range e {
+		switch v := e[i].(type) {
+		case string:
+			names[i] = v
+		case Entry:
+			names[i] = v.Name
+		default:
+			return fmt.Errorf("Unsupported type to delete: %s", v)
+		}
+	}
+	c.con.LogAction("(delete) address objects: %v", names)
 
-    path := c.xpath(vsys, names)
-    _, err = c.con.Delete(path, nil, nil)
-    return err
+	path := c.xpath(vsys, names)
+	_, err = c.con.Delete(path, nil, nil)
+	return err
 }
 
 /** Internal functions for the FwAddr struct **/
 
-func (c *FwAddr) versioning() (normalizer, func(Entry) (interface{})) {
-    v := c.con.Versioning()
+func (c *FwAddr) versioning() (normalizer, func(Entry) interface{}) {
+	v := c.con.Versioning()
 
-    if v.Gte(version.Number{9, 0, 0, ""}) {
-        return &container_v2{}, specify_v2
-    } else {
-        return &container_v1{}, specify_v1
-    }
+	if v.Gte(version.Number{9, 0, 0, ""}) {
+		return &container_v2{}, specify_v2
+	} else {
+		return &container_v1{}, specify_v1
+	}
 }
 
 func (c *FwAddr) details(fn util.Retriever, vsys, name string) (Entry, error) {
-    path := c.xpath(vsys, []string{name})
-    obj, _ := c.versioning()
-    _, err := fn(path, nil, obj)
-    if err != nil {
-        return Entry{}, err
-    }
-    ans := obj.Normalize()
+	path := c.xpath(vsys, []string{name})
+	obj, _ := c.versioning()
+	_, err := fn(path, nil, obj)
+	if err != nil {
+		return Entry{}, err
+	}
+	ans := obj.Normalize()
 
-    return ans, nil
+	return ans, nil
 }
 
 func (c *FwAddr) xpath(vsys string, vals []string) []string {
-    if vsys == "" {
-        vsys = "vsys1"
-    }
+	if vsys == "" {
+		vsys = "vsys1"
+	}
 
-    if vsys == "shared" {
-        return []string {
-            "config",
-            "shared",
-            "address",
-            util.AsEntryXpath(vals),
-        }
-    }
+	if vsys == "shared" {
+		return []string{
+			"config",
+			"shared",
+			"address",
+			util.AsEntryXpath(vals),
+		}
+	}
 
-    return []string {
-        "config",
-        "devices",
-        util.AsEntryXpath([]string{"localhost.localdomain"}),
-        "vsys",
-        util.AsEntryXpath([]string{vsys}),
-        "address",
-        util.AsEntryXpath(vals),
-    }
+	return []string{
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"vsys",
+		util.AsEntryXpath([]string{vsys}),
+		"address",
+		util.AsEntryXpath(vals),
+	}
 }

--- a/objs/addr/pano.go
+++ b/objs/addr/pano.go
@@ -1,170 +1,194 @@
 package addr
 
 import (
-    "fmt"
-    "encoding/xml"
+	"encoding/xml"
+	"fmt"
 
-    "github.com/PaloAltoNetworks/pango/util"
-    "github.com/PaloAltoNetworks/pango/version"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
 )
 
 // PanoAddr is a namespace struct, included as part of pango.Firewall.
 type PanoAddr struct {
-    con util.XapiClient
+	con util.XapiClient
 }
 
 // Initialize is invoked when Initialize on the pango.Client is called.
 func (c *PanoAddr) Initialize(con util.XapiClient) {
-    c.con = con
+	c.con = con
 }
 
 // GetList performs GET to retrieve a list of address objects.
 func (c *PanoAddr) GetList(dg string) ([]string, error) {
-    c.con.LogQuery("(get) list of address objects")
-    path := c.xpath(dg, nil)
-    return c.con.EntryListUsing(c.con.Get, path[:len(path) - 1])
+	c.con.LogQuery("(get) list of address objects")
+	path := c.xpath(dg, nil)
+	return c.con.EntryListUsing(c.con.Get, path[:len(path)-1])
+}
+
+// GetFullList performs GET to retreive a list of address objects.
+func (c *PanoAddr) GetFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(get) list of address objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // ShowList performs SHOW to retrieve a list of address objects.
 func (c *PanoAddr) ShowList(dg string) ([]string, error) {
-    c.con.LogQuery("(show) list of address objects")
-    path := c.xpath(dg, nil)
-    return c.con.EntryListUsing(c.con.Show, path[:len(path) - 1])
+	c.con.LogQuery("(show) list of address objects")
+	path := c.xpath(dg, nil)
+	return c.con.EntryListUsing(c.con.Show, path[:len(path)-1])
+}
+
+// ShowFullList performs SHOW to retreive a list of address objects.
+func (c *PanoAddr) ShowFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(show) list of address objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Show, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // Get performs GET to retrieve information for the given address object.
 func (c *PanoAddr) Get(dg, name string) (Entry, error) {
-    c.con.LogQuery("(get) address object %q", name)
-    return c.details(c.con.Get, dg, name)
+	c.con.LogQuery("(get) address object %q", name)
+	return c.details(c.con.Get, dg, name)
 }
 
 // Get performs SHOW to retrieve information for the given address object.
 func (c *PanoAddr) Show(dg, name string) (Entry, error) {
-    c.con.LogQuery("(show) address object %q", name)
-    return c.details(c.con.Show, dg, name)
+	c.con.LogQuery("(show) address object %q", name)
+	return c.details(c.con.Show, dg, name)
 }
 
 // Set performs SET to create / update one or more address objects.
 func (c *PanoAddr) Set(dg string, e ...Entry) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    _, fn := c.versioning()
-    names := make([]string, len(e))
+	_, fn := c.versioning()
+	names := make([]string, len(e))
 
-    // Build up the struct with the given configs.
-    d := util.BulkElement{XMLName: xml.Name{Local: "address"}}
-    for i := range e {
-        d.Data = append(d.Data, fn(e[i]))
-        names[i] = e[i].Name
-    }
-    c.con.LogAction("(set) address objects: %v", names)
+	// Build up the struct with the given configs.
+	d := util.BulkElement{XMLName: xml.Name{Local: "address"}}
+	for i := range e {
+		d.Data = append(d.Data, fn(e[i]))
+		names[i] = e[i].Name
+	}
+	c.con.LogAction("(set) address objects: %v", names)
 
-    // Set xpath.
-    path := c.xpath(dg, names)
-    if len(e) == 1 {
-        path = path[:len(path) - 1]
-    } else {
-        path = path[:len(path) - 2]
-    }
+	// Set xpath.
+	path := c.xpath(dg, names)
+	if len(e) == 1 {
+		path = path[:len(path)-1]
+	} else {
+		path = path[:len(path)-2]
+	}
 
-    // Create the objects.
-    _, err = c.con.Set(path, d.Config(), nil, nil)
-    return err
+	// Create the objects.
+	_, err = c.con.Set(path, d.Config(), nil, nil)
+	return err
 }
 
 // Edit performs EDIT to create / update an address object.
 func (c *PanoAddr) Edit(dg string, e Entry) error {
-    var err error
+	var err error
 
-    _, fn := c.versioning()
+	_, fn := c.versioning()
 
-    c.con.LogAction("(edit) address object %q", e.Name)
+	c.con.LogAction("(edit) address object %q", e.Name)
 
-    // Set xpath.
-    path := c.xpath(dg, []string{e.Name})
+	// Set xpath.
+	path := c.xpath(dg, []string{e.Name})
 
-    // Create the objects.
-    _, err = c.con.Edit(path, fn(e), nil, nil)
-    return err
+	// Create the objects.
+	_, err = c.con.Edit(path, fn(e), nil, nil)
+	return err
 }
 
 // Delete removes the given address objects from the firewall.
 //
 // Address objects can be either a string or an Entry object.
 func (c *PanoAddr) Delete(dg string, e ...interface{}) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    names := make([]string, len(e))
-    for i := range e {
-        switch v := e[i].(type) {
-        case string:
-            names[i] = v
-        case Entry:
-            names[i] = v.Name
-        default:
-            return fmt.Errorf("Unsupported type to delete: %s", v)
-        }
-    }
-    c.con.LogAction("(delete) address objects: %v", names)
+	names := make([]string, len(e))
+	for i := range e {
+		switch v := e[i].(type) {
+		case string:
+			names[i] = v
+		case Entry:
+			names[i] = v.Name
+		default:
+			return fmt.Errorf("Unsupported type to delete: %s", v)
+		}
+	}
+	c.con.LogAction("(delete) address objects: %v", names)
 
-    path := c.xpath(dg, names)
-    _, err = c.con.Delete(path, nil, nil)
-    return err
+	path := c.xpath(dg, names)
+	_, err = c.con.Delete(path, nil, nil)
+	return err
 }
 
 /** Internal functions for the PanoAddr struct **/
 
-func (c *PanoAddr) versioning() (normalizer, func(Entry) (interface{})) {
-    v := c.con.Versioning()
+func (c *PanoAddr) versioning() (normalizer, func(Entry) interface{}) {
+	v := c.con.Versioning()
 
-    if v.Gte(version.Number{9, 0, 0, ""}) {
-        return &container_v2{}, specify_v2
-    } else {
-        return &container_v1{}, specify_v1
-    }
+	if v.Gte(version.Number{9, 0, 0, ""}) {
+		return &container_v2{}, specify_v2
+	} else {
+		return &container_v1{}, specify_v1
+	}
 }
 
 func (c *PanoAddr) details(fn util.Retriever, dg, name string) (Entry, error) {
-    path := c.xpath(dg, []string{name})
-    obj, _ := c.versioning()
-    _, err := fn(path, nil, obj)
-    if err != nil {
-        return Entry{}, err
-    }
-    ans := obj.Normalize()
+	path := c.xpath(dg, []string{name})
+	obj, _ := c.versioning()
+	_, err := fn(path, nil, obj)
+	if err != nil {
+		return Entry{}, err
+	}
+	ans := obj.Normalize()
 
-    return ans, nil
+	return ans, nil
 }
 
 func (c *PanoAddr) xpath(dg string, vals []string) []string {
-    if dg == "" {
-        dg = "shared"
-    }
+	if dg == "" {
+		dg = "shared"
+	}
 
-    if dg == "shared" {
-        return []string {
-            "config",
-            "shared",
-            "address",
-            util.AsEntryXpath(vals),
-        }
-    }
+	if dg == "shared" {
+		return []string{
+			"config",
+			"shared",
+			"address",
+			util.AsEntryXpath(vals),
+		}
+	}
 
-    return []string {
-        "config",
-        "devices",
-        util.AsEntryXpath([]string{"localhost.localdomain"}),
-        "device-group",
-        util.AsEntryXpath([]string{dg}),
-        "address",
-        util.AsEntryXpath(vals),
-    }
+	return []string{
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"device-group",
+		util.AsEntryXpath([]string{dg}),
+		"address",
+		util.AsEntryXpath(vals),
+	}
 }

--- a/objs/srvc/entry.go
+++ b/objs/srvc/entry.go
@@ -1,230 +1,261 @@
 package srvc
 
 import (
-    "encoding/xml"
+	"encoding/xml"
 
-    "github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/util"
 )
-
 
 // Entry is a normalized, version independent representation of a service
 // object.
 //
 // Protocol should be either "tcp" or "udp".
 type Entry struct {
-    Name string
-    Description string
-    Protocol string
-    SourcePort string
-    DestinationPort string
-    Tags []string // ordered
-    OverrideSessionTimeout bool // 8.1+
-    OverrideTimeout int // 8.1+
-    OverrideHalfClosedTimeout int // 8.1+
-    OverrideTimeWaitTimeout int // 8.1+
+	Name                      string
+	Description               string
+	Protocol                  string
+	SourcePort                string
+	DestinationPort           string
+	Tags                      []string // ordered
+	OverrideSessionTimeout    bool     // 8.1+
+	OverrideTimeout           int      // 8.1+
+	OverrideHalfClosedTimeout int      // 8.1+
+	OverrideTimeWaitTimeout   int      // 8.1+
 }
 
 // Copy copies the information from source Entry `s` to this object.  As the
 // Name field relates to the XPATH of this object, this field is not copied.
 func (o *Entry) Copy(s Entry) {
-    o.Description = s.Description
-    o.Protocol = s.Protocol
-    o.SourcePort = s.SourcePort
-    o.DestinationPort = s.DestinationPort
-    o.Tags = s.Tags
-    o.OverrideSessionTimeout = s.OverrideSessionTimeout
-    o.OverrideTimeout = s.OverrideTimeout
-    o.OverrideHalfClosedTimeout = s.OverrideHalfClosedTimeout
-    o.OverrideTimeWaitTimeout = s.OverrideTimeWaitTimeout
+	o.Description = s.Description
+	o.Protocol = s.Protocol
+	o.SourcePort = s.SourcePort
+	o.DestinationPort = s.DestinationPort
+	o.Tags = s.Tags
+	o.OverrideSessionTimeout = s.OverrideSessionTimeout
+	o.OverrideTimeout = s.OverrideTimeout
+	o.OverrideHalfClosedTimeout = s.OverrideHalfClosedTimeout
+	o.OverrideTimeWaitTimeout = s.OverrideTimeWaitTimeout
 }
 
 /** Structs / functions for normalization. **/
 
 type normalizer interface {
-    Normalize() Entry
+	Normalize() Entry
 }
 
 type container_v1 struct {
-    Answer entry_v1 `xml:"result>entry"`
+	Answer entry_v1 `xml:"result>entry"`
 }
 
 func (o *container_v1) Normalize() Entry {
-    ans := Entry{
-        Name: o.Answer.Name,
-        Description: o.Answer.Description,
-        Tags: util.MemToStr(o.Answer.Tags),
-    }
-    switch {
-    case o.Answer.TcpProto != nil:
-        ans.Protocol = ProtocolTcp
-        ans.SourcePort = o.Answer.TcpProto.SourcePort
-        ans.DestinationPort = o.Answer.TcpProto.DestinationPort
-    case o.Answer.UdpProto != nil:
-        ans.Protocol = ProtocolUdp
-        ans.SourcePort = o.Answer.UdpProto.SourcePort
-        ans.DestinationPort = o.Answer.UdpProto.DestinationPort
-    }
+	ans := Entry{
+		Name:        o.Answer.Name,
+		Description: o.Answer.Description,
+		Tags:        util.MemToStr(o.Answer.Tags),
+	}
+	switch {
+	case o.Answer.TcpProto != nil:
+		ans.Protocol = ProtocolTcp
+		ans.SourcePort = o.Answer.TcpProto.SourcePort
+		ans.DestinationPort = o.Answer.TcpProto.DestinationPort
+	case o.Answer.UdpProto != nil:
+		ans.Protocol = ProtocolUdp
+		ans.SourcePort = o.Answer.UdpProto.SourcePort
+		ans.DestinationPort = o.Answer.UdpProto.DestinationPort
+	}
 
-    return ans
+	return ans
 }
 
 type container_v2 struct {
-    Answer entry_v2 `xml:"result>entry"`
+	Answer entry_v2 `xml:"result>entry"`
 }
 
 func (o *container_v2) Normalize() Entry {
-    ans := Entry{
-        Name: o.Answer.Name,
-        Description: o.Answer.Description,
-        Tags: util.MemToStr(o.Answer.Tags),
-    }
+	ans := Entry{
+		Name:        o.Answer.Name,
+		Description: o.Answer.Description,
+		Tags:        util.MemToStr(o.Answer.Tags),
+	}
 
-    switch {
-    case o.Answer.TcpProto != nil:
-        ans.Protocol = ProtocolTcp
-        ans.SourcePort = o.Answer.TcpProto.SourcePort
-        ans.DestinationPort = o.Answer.TcpProto.DestinationPort
-        if o.Answer.TcpProto.Override != nil && o.Answer.TcpProto.Override.Yes != nil {
-            ans.OverrideSessionTimeout = true
-            ans.OverrideTimeout = o.Answer.TcpProto.Override.Yes.OverrideTimeout
-            ans.OverrideHalfClosedTimeout = o.Answer.TcpProto.Override.Yes.OverrideHalfClosedTimeout
-            ans.OverrideTimeWaitTimeout = o.Answer.TcpProto.Override.Yes.OverrideTimeWaitTimeout
-        }
-    case o.Answer.UdpProto != nil:
-        ans.Protocol = ProtocolUdp
-        ans.SourcePort = o.Answer.UdpProto.SourcePort
-        ans.DestinationPort = o.Answer.UdpProto.DestinationPort
-        if o.Answer.UdpProto.Override != nil && o.Answer.UdpProto.Override.Yes != nil {
-            ans.OverrideSessionTimeout = true
-            ans.OverrideTimeout = o.Answer.UdpProto.Override.Yes.OverrideTimeout
-        }
-    case o.Answer.SctpProto != nil:
-        ans.Protocol = ProtocolSctp
-        ans.SourcePort = o.Answer.SctpProto.SourcePort
-        ans.DestinationPort = o.Answer.SctpProto.DestinationPort
-    }
+	switch {
+	case o.Answer.TcpProto != nil:
+		ans.Protocol = ProtocolTcp
+		ans.SourcePort = o.Answer.TcpProto.SourcePort
+		ans.DestinationPort = o.Answer.TcpProto.DestinationPort
+		if o.Answer.TcpProto.Override != nil && o.Answer.TcpProto.Override.Yes != nil {
+			ans.OverrideSessionTimeout = true
+			ans.OverrideTimeout = o.Answer.TcpProto.Override.Yes.OverrideTimeout
+			ans.OverrideHalfClosedTimeout = o.Answer.TcpProto.Override.Yes.OverrideHalfClosedTimeout
+			ans.OverrideTimeWaitTimeout = o.Answer.TcpProto.Override.Yes.OverrideTimeWaitTimeout
+		}
+	case o.Answer.UdpProto != nil:
+		ans.Protocol = ProtocolUdp
+		ans.SourcePort = o.Answer.UdpProto.SourcePort
+		ans.DestinationPort = o.Answer.UdpProto.DestinationPort
+		if o.Answer.UdpProto.Override != nil && o.Answer.UdpProto.Override.Yes != nil {
+			ans.OverrideSessionTimeout = true
+			ans.OverrideTimeout = o.Answer.UdpProto.Override.Yes.OverrideTimeout
+		}
+	case o.Answer.SctpProto != nil:
+		ans.Protocol = ProtocolSctp
+		ans.SourcePort = o.Answer.SctpProto.SourcePort
+		ans.DestinationPort = o.Answer.SctpProto.DestinationPort
+	}
 
-    return ans
+	return ans
 }
 
 type entry_v1 struct {
-    XMLName xml.Name `xml:"entry"`
-    Name string `xml:"name,attr"`
-    TcpProto *protoDef `xml:"protocol>tcp"`
-    UdpProto *protoDef `xml:"protocol>udp"`
-    Description string `xml:"description"`
-    Tags *util.MemberType `xml:"tag"`
+	XMLName     xml.Name         `xml:"entry"`
+	Name        string           `xml:"name,attr"`
+	TcpProto    *protoDef        `xml:"protocol>tcp"`
+	UdpProto    *protoDef        `xml:"protocol>udp"`
+	Description string           `xml:"description"`
+	Tags        *util.MemberType `xml:"tag"`
 }
 
 type protoDef struct {
-    SourcePort string `xml:"source-port,omitempty"`
-    DestinationPort string `xml:"port"`
+	SourcePort      string `xml:"source-port,omitempty"`
+	DestinationPort string `xml:"port"`
 }
 
 func specify_v1(e Entry) interface{} {
-    ans := entry_v1{
-        Name: e.Name,
-        Description: e.Description,
-        Tags: util.StrToMem(e.Tags),
-    }
-    switch e.Protocol {
-    case ProtocolTcp:
-        ans.TcpProto = &protoDef{
-            e.SourcePort,
-            e.DestinationPort,
-        }
-    case ProtocolUdp:
-        ans.UdpProto = &protoDef{
-            e.SourcePort,
-            e.DestinationPort,
-        }
-    }
+	ans := entry_v1{
+		Name:        e.Name,
+		Description: e.Description,
+		Tags:        util.StrToMem(e.Tags),
+	}
+	switch e.Protocol {
+	case ProtocolTcp:
+		ans.TcpProto = &protoDef{
+			e.SourcePort,
+			e.DestinationPort,
+		}
+	case ProtocolUdp:
+		ans.UdpProto = &protoDef{
+			e.SourcePort,
+			e.DestinationPort,
+		}
+	}
 
-    return ans
+	return ans
 }
 
 type entry_v2 struct {
-    XMLName xml.Name `xml:"entry"`
-    Name string `xml:"name,attr"`
-    TcpProto *tcpProto `xml:"protocol>tcp"`
-    UdpProto *udpProto `xml:"protocol>udp"`
-    SctpProto *protoDef `xml:"protocol>sctp"`
-    Description string `xml:"description"`
-    Tags *util.MemberType `xml:"tag"`
+	XMLName     xml.Name         `xml:"entry"`
+	Name        string           `xml:"name,attr"`
+	TcpProto    *tcpProto        `xml:"protocol>tcp"`
+	UdpProto    *udpProto        `xml:"protocol>udp"`
+	SctpProto   *protoDef        `xml:"protocol>sctp"`
+	Description string           `xml:"description"`
+	Tags        *util.MemberType `xml:"tag"`
 }
 
 type tcpProto struct {
-    SourcePort string `xml:"source-port,omitempty"`
-    DestinationPort string `xml:"port"`
-    Override *tcpOverride `xml:"override"`
+	SourcePort      string       `xml:"source-port,omitempty"`
+	DestinationPort string       `xml:"port"`
+	Override        *tcpOverride `xml:"override"`
 }
 
 type tcpOverride struct {
-    No *string `xml:"no"`
-    Yes *yesTcpOverride `xml:"yes"`
+	No  *string         `xml:"no"`
+	Yes *yesTcpOverride `xml:"yes"`
 }
 
 type yesTcpOverride struct {
-    OverrideTimeout int `xml:"timeout,omitempty"`
-    OverrideHalfClosedTimeout int `xml:"halfclose-timeout,omitempty"`
-    OverrideTimeWaitTimeout int `xml:"timewait-timeout,omitempty"`
+	OverrideTimeout           int `xml:"timeout,omitempty"`
+	OverrideHalfClosedTimeout int `xml:"halfclose-timeout,omitempty"`
+	OverrideTimeWaitTimeout   int `xml:"timewait-timeout,omitempty"`
 }
 
 type udpProto struct {
-    SourcePort string `xml:"source-port,omitempty"`
-    DestinationPort string `xml:"port"`
-    Override *udpOverride `xml:"override"`
+	SourcePort      string       `xml:"source-port,omitempty"`
+	DestinationPort string       `xml:"port"`
+	Override        *udpOverride `xml:"override"`
 }
 
 type udpOverride struct {
-    No *string `xml:"no"`
-    Yes *yesUdpOverride `xml:"yes"`
+	No  *string         `xml:"no"`
+	Yes *yesUdpOverride `xml:"yes"`
 }
 
 type yesUdpOverride struct {
-    OverrideTimeout int `xml:"timeout,omitempty"`
+	OverrideTimeout int `xml:"timeout,omitempty"`
 }
 
 func specify_v2(e Entry) interface{} {
-    ans := entry_v2{
-        Name: e.Name,
-        Description: e.Description,
-        Tags: util.StrToMem(e.Tags),
-    }
+	ans := entry_v2{
+		Name:        e.Name,
+		Description: e.Description,
+		Tags:        util.StrToMem(e.Tags),
+	}
 
-    switch e.Protocol {
-    case ProtocolTcp:
-        ans.TcpProto = &tcpProto{
-            SourcePort: e.SourcePort,
-            DestinationPort: e.DestinationPort,
-        }
-        if e.OverrideSessionTimeout {
-            ans.TcpProto.Override = &tcpOverride{
-                Yes: &yesTcpOverride{
-                    OverrideTimeout: e.OverrideTimeout,
-                    OverrideHalfClosedTimeout: e.OverrideHalfClosedTimeout,
-                    OverrideTimeWaitTimeout: e.OverrideTimeWaitTimeout,
-                },
-            }
-        }
-    case ProtocolUdp:
-        ans.UdpProto = &udpProto{
-            SourcePort: e.SourcePort,
-            DestinationPort: e.DestinationPort,
-        }
-        if e.OverrideSessionTimeout {
-            ans.UdpProto.Override = &udpOverride{
-                Yes: &yesUdpOverride{
-                    OverrideTimeout: e.OverrideTimeout,
-                },
-            }
-        }
-    case ProtocolSctp:
-        ans.SctpProto = &protoDef{
-            SourcePort: e.SourcePort,
-            DestinationPort: e.DestinationPort,
-        }
-    }
+	switch e.Protocol {
+	case ProtocolTcp:
+		ans.TcpProto = &tcpProto{
+			SourcePort:      e.SourcePort,
+			DestinationPort: e.DestinationPort,
+		}
+		if e.OverrideSessionTimeout {
+			ans.TcpProto.Override = &tcpOverride{
+				Yes: &yesTcpOverride{
+					OverrideTimeout:           e.OverrideTimeout,
+					OverrideHalfClosedTimeout: e.OverrideHalfClosedTimeout,
+					OverrideTimeWaitTimeout:   e.OverrideTimeWaitTimeout,
+				},
+			}
+		}
+	case ProtocolUdp:
+		ans.UdpProto = &udpProto{
+			SourcePort:      e.SourcePort,
+			DestinationPort: e.DestinationPort,
+		}
+		if e.OverrideSessionTimeout {
+			ans.UdpProto.Override = &udpOverride{
+				Yes: &yesUdpOverride{
+					OverrideTimeout: e.OverrideTimeout,
+				},
+			}
+		}
+	case ProtocolSctp:
+		ans.SctpProto = &protoDef{
+			SourcePort:      e.SourcePort,
+			DestinationPort: e.DestinationPort,
+		}
+	}
 
-    return ans
+	return ans
+}
+
+//EntryContainerMulti container for full list of address objects
+type EntryContainerMulti struct {
+	Entries []Entry `xml:"response>result>service>entry"`
+}
+
+//UnmarshalXML parses raw result for the service object xml tree
+func (e *EntryContainerMulti) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for {
+		token, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch childToken := token.(type) {
+		case xml.StartElement:
+			switch childToken.Name.Local {
+			case "entry":
+				entry := entry_v2{}
+				err = d.DecodeElement(&entry, &childToken)
+				if err != nil {
+					return err
+				}
+				containerized := container_v2{entry}
+				e.Entries = append(e.Entries, containerized.Normalize())
+			}
+		case xml.EndElement:
+			if childToken == start.End() {
+				return nil
+			}
+		}
+	}
 }

--- a/objs/srvc/fw.go
+++ b/objs/srvc/fw.go
@@ -1,171 +1,194 @@
 package srvc
 
 import (
-    "fmt"
-    "encoding/xml"
+	"encoding/xml"
+	"fmt"
 
-    "github.com/PaloAltoNetworks/pango/util"
-    "github.com/PaloAltoNetworks/pango/version"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
 )
-
 
 // FwSrvc is a namespace struct, included as part of pango.Client.
 type FwSrvc struct {
-    con util.XapiClient
+	con util.XapiClient
 }
 
 // Initialize is invoked when Initialize on the pango.Client is called.
 func (c *FwSrvc) Initialize(con util.XapiClient) {
-    c.con = con
+	c.con = con
 }
 
 // GetList performs GET to retrieve a list of service objects.
 func (c *FwSrvc) GetList(vsys string) ([]string, error) {
-    c.con.LogQuery("(get) list of service objects")
-    path := c.xpath(vsys, nil)
-    return c.con.EntryListUsing(c.con.Get, path[:len(path) - 1])
+	c.con.LogQuery("(get) list of service objects")
+	path := c.xpath(vsys, nil)
+	return c.con.EntryListUsing(c.con.Get, path[:len(path)-1])
+}
+
+// GetFullList performs GET to retreive a list of service objects.
+func (c *FwSrvc) GetFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(get) list of service objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // ShowList performs SHOW to retrieve a list of service objects.
 func (c *FwSrvc) ShowList(vsys string) ([]string, error) {
-    c.con.LogQuery("(show) list of service objects")
-    path := c.xpath(vsys, nil)
-    return c.con.EntryListUsing(c.con.Show, path[:len(path) - 1])
+	c.con.LogQuery("(show) list of service objects")
+	path := c.xpath(vsys, nil)
+	return c.con.EntryListUsing(c.con.Show, path[:len(path)-1])
+}
+
+// ShowFullList performs SHO to retreive a list of service objects.
+func (c *FwSrvc) ShowFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(get) list of service objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Show, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // Get performs GET to retrieve information for the given service object.
 func (c *FwSrvc) Get(vsys, name string) (Entry, error) {
-    c.con.LogQuery("(get) service object %q", name)
-    return c.details(c.con.Get, vsys, name)
+	c.con.LogQuery("(get) service object %q", name)
+	return c.details(c.con.Get, vsys, name)
 }
 
 // Get performs SHOW to retrieve information for the given service object.
 func (c *FwSrvc) Show(vsys, name string) (Entry, error) {
-    c.con.LogQuery("(show) service object %q", name)
-    return c.details(c.con.Show, vsys, name)
+	c.con.LogQuery("(show) service object %q", name)
+	return c.details(c.con.Show, vsys, name)
 }
 
 // Set performs SET to create / update one or more service objects.
 func (c *FwSrvc) Set(vsys string, e ...Entry) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    _, fn := c.versioning()
-    names := make([]string, len(e))
+	_, fn := c.versioning()
+	names := make([]string, len(e))
 
-    // Build up the struct with the given configs.
-    d := util.BulkElement{XMLName: xml.Name{Local: "service"}}
-    for i := range e {
-        d.Data = append(d.Data, fn(e[i]))
-        names[i] = e[i].Name
-    }
-    c.con.LogAction("(set) service objects: %v", names)
+	// Build up the struct with the given configs.
+	d := util.BulkElement{XMLName: xml.Name{Local: "service"}}
+	for i := range e {
+		d.Data = append(d.Data, fn(e[i]))
+		names[i] = e[i].Name
+	}
+	c.con.LogAction("(set) service objects: %v", names)
 
-    // Set xpath.
-    path := c.xpath(vsys, names)
-    if len(e) == 1 {
-        path = path[:len(path) - 1]
-    } else {
-        path = path[:len(path) - 2]
-    }
+	// Set xpath.
+	path := c.xpath(vsys, names)
+	if len(e) == 1 {
+		path = path[:len(path)-1]
+	} else {
+		path = path[:len(path)-2]
+	}
 
-    // Create the objects.
-    _, err = c.con.Set(path, d.Config(), nil, nil)
-    return err
+	// Create the objects.
+	_, err = c.con.Set(path, d.Config(), nil, nil)
+	return err
 }
 
 // Edit performs EDIT to create / update a service object.
 func (c *FwSrvc) Edit(vsys string, e Entry) error {
-    var err error
+	var err error
 
-    _, fn := c.versioning()
+	_, fn := c.versioning()
 
-    c.con.LogAction("(edit) service object %q", e.Name)
+	c.con.LogAction("(edit) service object %q", e.Name)
 
-    // Set xpath.
-    path := c.xpath(vsys, []string{e.Name})
+	// Set xpath.
+	path := c.xpath(vsys, []string{e.Name})
 
-    // Create the object.
-    _, err = c.con.Edit(path, fn(e), nil, nil)
-    return err
+	// Create the object.
+	_, err = c.con.Edit(path, fn(e), nil, nil)
+	return err
 }
 
 // Delete removes the given service objects from the firewall.
 //
 // Service objects can be either a string or an Entry object.
 func (c *FwSrvc) Delete(vsys string, e ...interface{}) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    names := make([]string, len(e))
-    for i := range e {
-        switch v := e[i].(type) {
-        case string:
-            names[i] = v
-        case Entry:
-            names[i] = v.Name
-        default:
-            return fmt.Errorf("Unsupported type to delete: %s", v)
-        }
-    }
-    c.con.LogAction("(delete) service objects: %v", names)
+	names := make([]string, len(e))
+	for i := range e {
+		switch v := e[i].(type) {
+		case string:
+			names[i] = v
+		case Entry:
+			names[i] = v.Name
+		default:
+			return fmt.Errorf("Unsupported type to delete: %s", v)
+		}
+	}
+	c.con.LogAction("(delete) service objects: %v", names)
 
-    path := c.xpath(vsys, names)
-    _, err = c.con.Delete(path, nil, nil)
-    return err
+	path := c.xpath(vsys, names)
+	_, err = c.con.Delete(path, nil, nil)
+	return err
 }
 
 /** Internal functions for the FwSrvc struct **/
 
-func (c *FwSrvc) versioning() (normalizer, func(Entry) (interface{})) {
-    v := c.con.Versioning()
+func (c *FwSrvc) versioning() (normalizer, func(Entry) interface{}) {
+	v := c.con.Versioning()
 
-    if v.Gte(version.Number{8, 1, 0, ""}) {
-        return &container_v2{}, specify_v2
-    } else {
-        return &container_v1{}, specify_v1
-    }
+	if v.Gte(version.Number{8, 1, 0, ""}) {
+		return &container_v2{}, specify_v2
+	} else {
+		return &container_v1{}, specify_v1
+	}
 }
 
 func (c *FwSrvc) details(fn util.Retriever, vsys, name string) (Entry, error) {
-    path := c.xpath(vsys, []string{name})
-    obj, _ := c.versioning()
-    _, err := fn(path, nil, obj)
-    if err != nil {
-        return Entry{}, err
-    }
-    ans := obj.Normalize()
+	path := c.xpath(vsys, []string{name})
+	obj, _ := c.versioning()
+	_, err := fn(path, nil, obj)
+	if err != nil {
+		return Entry{}, err
+	}
+	ans := obj.Normalize()
 
-    return ans, nil
+	return ans, nil
 }
 
 func (c *FwSrvc) xpath(vsys string, vals []string) []string {
-    if vsys == "" {
-        vsys = "vsys1"
-    }
+	if vsys == "" {
+		vsys = "vsys1"
+	}
 
-    if vsys == "shared" {
-        return []string {
-            "config",
-            "shared",
-            "service",
-            util.AsEntryXpath(vals),
-        }
-    }
+	if vsys == "shared" {
+		return []string{
+			"config",
+			"shared",
+			"service",
+			util.AsEntryXpath(vals),
+		}
+	}
 
-    return []string {
-        "config",
-        "devices",
-        util.AsEntryXpath([]string{"localhost.localdomain"}),
-        "vsys",
-        util.AsEntryXpath([]string{vsys}),
-        "service",
-        util.AsEntryXpath(vals),
-    }
+	return []string{
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"vsys",
+		util.AsEntryXpath([]string{vsys}),
+		"service",
+		util.AsEntryXpath(vals),
+	}
 }

--- a/objs/srvc/pano.go
+++ b/objs/srvc/pano.go
@@ -1,171 +1,194 @@
 package srvc
 
 import (
-    "fmt"
-    "encoding/xml"
+	"encoding/xml"
+	"fmt"
 
-    "github.com/PaloAltoNetworks/pango/util"
-    "github.com/PaloAltoNetworks/pango/version"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
 )
-
 
 // PanoSrvc is a namespace struct, included as part of pango.Client.
 type PanoSrvc struct {
-    con util.XapiClient
+	con util.XapiClient
 }
 
 // Initialize is invoked when Initialize on the pango.Client is called.
 func (c *PanoSrvc) Initialize(con util.XapiClient) {
-    c.con = con
+	c.con = con
 }
 
 // GetList performs GET to retrieve a list of service objects.
 func (c *PanoSrvc) GetList(dg string) ([]string, error) {
-    c.con.LogQuery("(get) list of service objects")
-    path := c.xpath(dg, nil)
-    return c.con.EntryListUsing(c.con.Get, path[:len(path) - 1])
+	c.con.LogQuery("(get) list of service objects")
+	path := c.xpath(dg, nil)
+	return c.con.EntryListUsing(c.con.Get, path[:len(path)-1])
+}
+
+// GetFullList performs GET to retreive a list of service objects.
+func (c *PanoSrvc) GetFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(get) list of service objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // ShowList performs SHOW to retrieve a list of service objects.
-func (c *PanoSrvc) ShowList(dg string) ([]string, error) {
-    c.con.LogQuery("(show) list of service objects")
-    path := c.xpath(dg, nil)
-    return c.con.EntryListUsing(c.con.Show, path[:len(path) - 1])
+func (c *PanoSrvc) ShowList(vsys string) ([]string, error) {
+	c.con.LogQuery("(show) list of service objects")
+	path := c.xpath(vsys, nil)
+	return c.con.EntryListUsing(c.con.Show, path[:len(path)-1])
+}
+
+// ShowFullList performs SHO to retreive a list of service objects.
+func (c *PanoSrvc) ShowFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(get) list of service objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Show, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // Get performs GET to retrieve information for the given service object.
 func (c *PanoSrvc) Get(dg, name string) (Entry, error) {
-    c.con.LogQuery("(get) service object %q", name)
-    return c.details(c.con.Get, dg, name)
+	c.con.LogQuery("(get) service object %q", name)
+	return c.details(c.con.Get, dg, name)
 }
 
 // Get performs SHOW to retrieve information for the given service object.
 func (c *PanoSrvc) Show(dg, name string) (Entry, error) {
-    c.con.LogQuery("(show) service object %q", name)
-    return c.details(c.con.Show, dg, name)
+	c.con.LogQuery("(show) service object %q", name)
+	return c.details(c.con.Show, dg, name)
 }
 
 // Set performs SET to create / update one or more service objects.
 func (c *PanoSrvc) Set(dg string, e ...Entry) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    _, fn := c.versioning()
-    names := make([]string, len(e))
+	_, fn := c.versioning()
+	names := make([]string, len(e))
 
-    // Build up the struct with the given configs.
-    d := util.BulkElement{XMLName: xml.Name{Local: "service"}}
-    for i := range e {
-        d.Data = append(d.Data, fn(e[i]))
-        names[i] = e[i].Name
-    }
-    c.con.LogAction("(set) service objects: %v", names)
+	// Build up the struct with the given configs.
+	d := util.BulkElement{XMLName: xml.Name{Local: "service"}}
+	for i := range e {
+		d.Data = append(d.Data, fn(e[i]))
+		names[i] = e[i].Name
+	}
+	c.con.LogAction("(set) service objects: %v", names)
 
-    // Set xpath.
-    path := c.xpath(dg, names)
-    if len(e) == 1 {
-        path = path[:len(path) - 1]
-    } else {
-        path = path[:len(path) - 2]
-    }
+	// Set xpath.
+	path := c.xpath(dg, names)
+	if len(e) == 1 {
+		path = path[:len(path)-1]
+	} else {
+		path = path[:len(path)-2]
+	}
 
-    // Create the objects.
-    _, err = c.con.Set(path, d.Config(), nil, nil)
-    return err
+	// Create the objects.
+	_, err = c.con.Set(path, d.Config(), nil, nil)
+	return err
 }
 
 // Edit performs EDIT to create / update a service object.
 func (c *PanoSrvc) Edit(dg string, e Entry) error {
-    var err error
+	var err error
 
-    _, fn := c.versioning()
+	_, fn := c.versioning()
 
-    c.con.LogAction("(edit) service object %q", e.Name)
+	c.con.LogAction("(edit) service object %q", e.Name)
 
-    // Set xpath.
-    path := c.xpath(dg, []string{e.Name})
+	// Set xpath.
+	path := c.xpath(dg, []string{e.Name})
 
-    // Create the object.
-    _, err = c.con.Edit(path, fn(e), nil, nil)
-    return err
+	// Create the object.
+	_, err = c.con.Edit(path, fn(e), nil, nil)
+	return err
 }
 
 // Delete removes the given service objects from the firewall.
 //
 // Service objects can be either a string or an Entry object.
 func (c *PanoSrvc) Delete(dg string, e ...interface{}) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    names := make([]string, len(e))
-    for i := range e {
-        switch v := e[i].(type) {
-        case string:
-            names[i] = v
-        case Entry:
-            names[i] = v.Name
-        default:
-            return fmt.Errorf("Unsupported type to delete: %s", v)
-        }
-    }
-    c.con.LogAction("(delete) service objects: %v", names)
+	names := make([]string, len(e))
+	for i := range e {
+		switch v := e[i].(type) {
+		case string:
+			names[i] = v
+		case Entry:
+			names[i] = v.Name
+		default:
+			return fmt.Errorf("Unsupported type to delete: %s", v)
+		}
+	}
+	c.con.LogAction("(delete) service objects: %v", names)
 
-    path := c.xpath(dg, names)
-    _, err = c.con.Delete(path, nil, nil)
-    return err
+	path := c.xpath(dg, names)
+	_, err = c.con.Delete(path, nil, nil)
+	return err
 }
 
 /** Internal functions for the PanoSrvc struct **/
 
-func (c *PanoSrvc) versioning() (normalizer, func(Entry) (interface{})) {
-    v := c.con.Versioning()
+func (c *PanoSrvc) versioning() (normalizer, func(Entry) interface{}) {
+	v := c.con.Versioning()
 
-    if v.Gte(version.Number{8, 1, 0, ""}) {
-        return &container_v2{}, specify_v2
-    } else {
-        return &container_v1{}, specify_v1
-    }
+	if v.Gte(version.Number{8, 1, 0, ""}) {
+		return &container_v2{}, specify_v2
+	} else {
+		return &container_v1{}, specify_v1
+	}
 }
 
 func (c *PanoSrvc) details(fn util.Retriever, dg, name string) (Entry, error) {
-    path := c.xpath(dg, []string{name})
-    obj, _ := c.versioning()
-    _, err := fn(path, nil, obj)
-    if err != nil {
-        return Entry{}, err
-    }
-    ans := obj.Normalize()
+	path := c.xpath(dg, []string{name})
+	obj, _ := c.versioning()
+	_, err := fn(path, nil, obj)
+	if err != nil {
+		return Entry{}, err
+	}
+	ans := obj.Normalize()
 
-    return ans, nil
+	return ans, nil
 }
 
 func (c *PanoSrvc) xpath(dg string, vals []string) []string {
-    if dg == "" {
-        dg = "shared"
-    }
+	if dg == "" {
+		dg = "shared"
+	}
 
-    if dg == "shared" {
-        return []string {
-            "config",
-            "shared",
-            "service",
-            util.AsEntryXpath(vals),
-        }
-    }
+	if dg == "shared" {
+		return []string{
+			"config",
+			"shared",
+			"service",
+			util.AsEntryXpath(vals),
+		}
+	}
 
-    return []string {
-        "config",
-        "devices",
-        util.AsEntryXpath([]string{"localhost.localdomain"}),
-        "device-group",
-        util.AsEntryXpath([]string{dg}),
-        "service",
-        util.AsEntryXpath(vals),
-    }
+	return []string{
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"device-group",
+		util.AsEntryXpath([]string{dg}),
+		"service",
+		util.AsEntryXpath(vals),
+	}
 }

--- a/poli/nat/entry.go
+++ b/poli/nat/entry.go
@@ -1,11 +1,10 @@
 package nat
 
 import (
-    "encoding/xml"
+	"encoding/xml"
 
-    "github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/util"
 )
-
 
 // Entry is a normalized, version independent representation of a NAT
 // policy.  The prefix "Sat" stands for "Source Address Translation" while
@@ -56,35 +55,35 @@ import (
 // address translation will be enabled; setting DatType by itself is not
 // good enough.
 type Entry struct {
-    Name string
-    Description string
-    Type string
-    SourceZones []string // unordered
-    DestinationZone string
-    ToInterface string
-    Service string
-    SourceAddresses []string // unordered
-    DestinationAddresses []string // unordered
-    SatType string
-    SatAddressType string
-    SatTranslatedAddresses []string // unordered
-    SatInterface string
-    SatIpAddress string
-    SatFallbackType string
-    SatFallbackTranslatedAddresses []string // unordered
-    SatFallbackInterface string
-    SatFallbackIpType string
-    SatFallbackIpAddress string
-    SatStaticTranslatedAddress string
-    SatStaticBiDirectional bool
-    DatType string
-    DatAddress string
-    DatPort int
-    DatDynamicDistribution string // 8.1+
-    Disabled bool
-    Targets map[string] []string
-    NegateTarget bool
-    Tags []string // ordered
+	Name                           string
+	Description                    string
+	Type                           string
+	SourceZones                    []string // unordered
+	DestinationZone                string
+	ToInterface                    string
+	Service                        string
+	SourceAddresses                []string // unordered
+	DestinationAddresses           []string // unordered
+	SatType                        string
+	SatAddressType                 string
+	SatTranslatedAddresses         []string // unordered
+	SatInterface                   string
+	SatIpAddress                   string
+	SatFallbackType                string
+	SatFallbackTranslatedAddresses []string // unordered
+	SatFallbackInterface           string
+	SatFallbackIpType              string
+	SatFallbackIpAddress           string
+	SatStaticTranslatedAddress     string
+	SatStaticBiDirectional         bool
+	DatType                        string
+	DatAddress                     string
+	DatPort                        int
+	DatDynamicDistribution         string // 8.1+
+	Disabled                       bool
+	Targets                        map[string][]string
+	NegateTarget                   bool
+	Tags                           []string // ordered
 }
 
 // Defaults sets params with uninitialized values to their GUI default setting.
@@ -98,480 +97,512 @@ type Entry struct {
 //      * SatType: None
 //      * DatType: DatTypeStatic
 func (o *Entry) Defaults() {
-    if o.Type == "" {
-        o.Type = "ipv4"
-    }
+	if o.Type == "" {
+		o.Type = "ipv4"
+	}
 
-    if o.ToInterface == "" {
-        o.ToInterface = "any"
-    }
+	if o.ToInterface == "" {
+		o.ToInterface = "any"
+	}
 
-    if o.Service == "" {
-        o.Service = "any"
-    }
+	if o.Service == "" {
+		o.Service = "any"
+	}
 
-    if len(o.SourceAddresses) == 0 {
-        o.SourceAddresses = []string{"any"}
-    }
+	if len(o.SourceAddresses) == 0 {
+		o.SourceAddresses = []string{"any"}
+	}
 
-    if len(o.DestinationAddresses) == 0 {
-        o.DestinationAddresses = []string{"any"}
-    }
+	if len(o.DestinationAddresses) == 0 {
+		o.DestinationAddresses = []string{"any"}
+	}
 
-    if o.SatType == "" {
-        o.SatType = None
-    }
+	if o.SatType == "" {
+		o.SatType = None
+	}
 
-    if o.DatType == "" {
-        o.DatType = DatTypeStatic
-    }
+	if o.DatType == "" {
+		o.DatType = DatTypeStatic
+	}
 }
 
 // Copy copies the information from source Entry `s` to this object.  As the
 // Name field relates to the XPATH of this object, this field is not copied.
 func (o *Entry) Copy(s Entry) {
-    o.Description = s.Description
-    o.Type = s.Type
-    o.SourceZones = s.SourceZones
-    o.DestinationZone = s.DestinationZone
-    o.ToInterface = s.ToInterface
-    o.Service = s.Service
-    o.SourceAddresses = s.SourceAddresses
-    o.DestinationAddresses = s.DestinationAddresses
-    o.SatType = s.SatType
-    o.SatAddressType = s.SatAddressType
-    o.SatTranslatedAddresses = s.SatTranslatedAddresses
-    o.SatInterface = s.SatInterface
-    o.SatIpAddress = s.SatIpAddress
-    o.SatFallbackType = s.SatFallbackType
-    o.SatFallbackTranslatedAddresses = s.SatFallbackTranslatedAddresses
-    o.SatFallbackInterface = s.SatFallbackInterface
-    o.SatFallbackIpType = s.SatFallbackIpType
-    o.SatFallbackIpAddress = s.SatFallbackIpAddress
-    o.SatStaticTranslatedAddress = s.SatStaticTranslatedAddress
-    o.SatStaticBiDirectional = s.SatStaticBiDirectional
-    o.DatAddress = s.DatAddress
-    o.DatPort = s.DatPort
-    o.Disabled = s.Disabled
-    o.Targets = s.Targets
-    o.NegateTarget = s.NegateTarget
-    o.Tags = s.Tags
-    o.DatType = s.DatType
-    o.DatDynamicDistribution = s.DatDynamicDistribution
+	o.Description = s.Description
+	o.Type = s.Type
+	o.SourceZones = s.SourceZones
+	o.DestinationZone = s.DestinationZone
+	o.ToInterface = s.ToInterface
+	o.Service = s.Service
+	o.SourceAddresses = s.SourceAddresses
+	o.DestinationAddresses = s.DestinationAddresses
+	o.SatType = s.SatType
+	o.SatAddressType = s.SatAddressType
+	o.SatTranslatedAddresses = s.SatTranslatedAddresses
+	o.SatInterface = s.SatInterface
+	o.SatIpAddress = s.SatIpAddress
+	o.SatFallbackType = s.SatFallbackType
+	o.SatFallbackTranslatedAddresses = s.SatFallbackTranslatedAddresses
+	o.SatFallbackInterface = s.SatFallbackInterface
+	o.SatFallbackIpType = s.SatFallbackIpType
+	o.SatFallbackIpAddress = s.SatFallbackIpAddress
+	o.SatStaticTranslatedAddress = s.SatStaticTranslatedAddress
+	o.SatStaticBiDirectional = s.SatStaticBiDirectional
+	o.DatAddress = s.DatAddress
+	o.DatPort = s.DatPort
+	o.Disabled = s.Disabled
+	o.Targets = s.Targets
+	o.NegateTarget = s.NegateTarget
+	o.Tags = s.Tags
+	o.DatType = s.DatType
+	o.DatDynamicDistribution = s.DatDynamicDistribution
 }
 
 /** Structs / functions for normalization. **/
 
 type normalizer interface {
-    Normalize() Entry
+	Normalize() Entry
 }
 
 type container_v1 struct {
-    Answer entry_v1 `xml:"result>entry"`
+	Answer entry_v1 `xml:"result>entry"`
 }
 
 func (o *container_v1) Normalize() Entry {
-    ans := Entry{
-        Name: o.Answer.Name,
-        Description: o.Answer.Description,
-        Type: o.Answer.Type,
-        SourceZones: util.MemToStr(o.Answer.SourceZones),
-        DestinationZone: o.Answer.DestinationZone,
-        ToInterface: o.Answer.ToInterface,
-        Service: o.Answer.Service,
-        SourceAddresses: util.MemToStr(o.Answer.SourceAddresses),
-        DestinationAddresses: util.MemToStr(o.Answer.DestinationAddresses),
-        Disabled: util.AsBool(o.Answer.Disabled),
-        Tags: util.MemToStr(o.Answer.Tags),
-    }
+	ans := Entry{
+		Name:                 o.Answer.Name,
+		Description:          o.Answer.Description,
+		Type:                 o.Answer.Type,
+		SourceZones:          util.MemToStr(o.Answer.SourceZones),
+		DestinationZone:      o.Answer.DestinationZone,
+		ToInterface:          o.Answer.ToInterface,
+		Service:              o.Answer.Service,
+		SourceAddresses:      util.MemToStr(o.Answer.SourceAddresses),
+		DestinationAddresses: util.MemToStr(o.Answer.DestinationAddresses),
+		Disabled:             util.AsBool(o.Answer.Disabled),
+		Tags:                 util.MemToStr(o.Answer.Tags),
+	}
 
-    if o.Answer.Sat == nil {
-        ans.SatType = None
-    } else {
-        switch {
-        case o.Answer.Sat.Diap != nil:
-            ans.SatType = DynamicIpAndPort
-            if o.Answer.Sat.Diap.InterfaceAddress != nil {
-                ans.SatAddressType = InterfaceAddress
-                ans.SatInterface = o.Answer.Sat.Diap.InterfaceAddress.Interface
-                ans.SatIpAddress = o.Answer.Sat.Diap.InterfaceAddress.Ip
-            } else {
-                ans.SatAddressType = TranslatedAddress
-                ans.SatTranslatedAddresses = util.MemToStr(o.Answer.Sat.Diap.TranslatedAddress)
-            }
-        case o.Answer.Sat.Di != nil:
-            ans.SatType = DynamicIp
-            ans.SatTranslatedAddresses = util.MemToStr(o.Answer.Sat.Di.TranslatedAddress)
-            if o.Answer.Sat.Di.Fallback == nil {
-                ans.SatFallbackType = None
-            } else if o.Answer.Sat.Di.Fallback.TranslatedAddress != nil {
-                ans.SatFallbackType = TranslatedAddress
-                ans.SatFallbackTranslatedAddresses = util.MemToStr(o.Answer.Sat.Di.Fallback.TranslatedAddress)
-            } else if o.Answer.Sat.Di.Fallback.InterfaceAddress != nil {
-                ans.SatFallbackType = InterfaceAddress
-                ans.SatFallbackInterface = o.Answer.Sat.Di.Fallback.InterfaceAddress.Interface
-                if o.Answer.Sat.Di.Fallback.InterfaceAddress.Ip != "" {
-                    ans.SatFallbackIpType = Ip
-                    ans.SatFallbackIpAddress = o.Answer.Sat.Di.Fallback.InterfaceAddress.Ip
-                } else if o.Answer.Sat.Di.Fallback.InterfaceAddress.FloatingIp != "" {
-                    ans.SatFallbackIpType = FloatingIp
-                    ans.SatFallbackIpAddress = o.Answer.Sat.Di.Fallback.InterfaceAddress.FloatingIp
-                }
-            }
-        case o.Answer.Sat.Static != nil:
-            ans.SatType = StaticIp
-            ans.SatStaticTranslatedAddress = o.Answer.Sat.Static.Address
-            ans.SatStaticBiDirectional = util.AsBool(o.Answer.Sat.Static.BiDirectional)
-        }
-    }
+	if o.Answer.Sat == nil {
+		ans.SatType = None
+	} else {
+		switch {
+		case o.Answer.Sat.Diap != nil:
+			ans.SatType = DynamicIpAndPort
+			if o.Answer.Sat.Diap.InterfaceAddress != nil {
+				ans.SatAddressType = InterfaceAddress
+				ans.SatInterface = o.Answer.Sat.Diap.InterfaceAddress.Interface
+				ans.SatIpAddress = o.Answer.Sat.Diap.InterfaceAddress.Ip
+			} else {
+				ans.SatAddressType = TranslatedAddress
+				ans.SatTranslatedAddresses = util.MemToStr(o.Answer.Sat.Diap.TranslatedAddress)
+			}
+		case o.Answer.Sat.Di != nil:
+			ans.SatType = DynamicIp
+			ans.SatTranslatedAddresses = util.MemToStr(o.Answer.Sat.Di.TranslatedAddress)
+			if o.Answer.Sat.Di.Fallback == nil {
+				ans.SatFallbackType = None
+			} else if o.Answer.Sat.Di.Fallback.TranslatedAddress != nil {
+				ans.SatFallbackType = TranslatedAddress
+				ans.SatFallbackTranslatedAddresses = util.MemToStr(o.Answer.Sat.Di.Fallback.TranslatedAddress)
+			} else if o.Answer.Sat.Di.Fallback.InterfaceAddress != nil {
+				ans.SatFallbackType = InterfaceAddress
+				ans.SatFallbackInterface = o.Answer.Sat.Di.Fallback.InterfaceAddress.Interface
+				if o.Answer.Sat.Di.Fallback.InterfaceAddress.Ip != "" {
+					ans.SatFallbackIpType = Ip
+					ans.SatFallbackIpAddress = o.Answer.Sat.Di.Fallback.InterfaceAddress.Ip
+				} else if o.Answer.Sat.Di.Fallback.InterfaceAddress.FloatingIp != "" {
+					ans.SatFallbackIpType = FloatingIp
+					ans.SatFallbackIpAddress = o.Answer.Sat.Di.Fallback.InterfaceAddress.FloatingIp
+				}
+			}
+		case o.Answer.Sat.Static != nil:
+			ans.SatType = StaticIp
+			ans.SatStaticTranslatedAddress = o.Answer.Sat.Static.Address
+			ans.SatStaticBiDirectional = util.AsBool(o.Answer.Sat.Static.BiDirectional)
+		}
+	}
 
-    if o.Answer.Dat != nil {
-        ans.DatType = DatTypeStatic
-        ans.DatAddress = o.Answer.Dat.Address
-        ans.DatPort = o.Answer.Dat.Port
-    }
+	if o.Answer.Dat != nil {
+		ans.DatType = DatTypeStatic
+		ans.DatAddress = o.Answer.Dat.Address
+		ans.DatPort = o.Answer.Dat.Port
+	}
 
-    if o.Answer.Target != nil {
-        ans.Targets = util.VsysEntToMap(o.Answer.Target.Targets)
-        ans.NegateTarget = util.AsBool(o.Answer.Target.NegateTarget)
-    }
+	if o.Answer.Target != nil {
+		ans.Targets = util.VsysEntToMap(o.Answer.Target.Targets)
+		ans.NegateTarget = util.AsBool(o.Answer.Target.NegateTarget)
+	}
 
-    return ans
+	return ans
 }
 
 type entry_v1 struct {
-    XMLName xml.Name `xml:"entry"`
-    Name string `xml:"name,attr"`
-    Description string `xml:"description"`
-    Type string `xml:"nat-type"`
-    SourceZones *util.MemberType `xml:"from"`
-    DestinationZone string `xml:"to>member"`
-    ToInterface string `xml:"to-interface"`
-    Service string `xml:"service"`
-    SourceAddresses *util.MemberType `xml:"source"`
-    DestinationAddresses *util.MemberType `xml:"destination"`
-    Sat *srcXlate `xml:"source-translation"`
-    Dat *dstXlate `xml:"destination-translation"`
-    Disabled string `xml:"disabled"`
-    Target *targetInfo `xml:"target"`
-    Tags *util.MemberType `xml:"tag"`
+	XMLName              xml.Name         `xml:"entry"`
+	Name                 string           `xml:"name,attr"`
+	Description          string           `xml:"description"`
+	Type                 string           `xml:"nat-type"`
+	SourceZones          *util.MemberType `xml:"from"`
+	DestinationZone      string           `xml:"to>member"`
+	ToInterface          string           `xml:"to-interface"`
+	Service              string           `xml:"service"`
+	SourceAddresses      *util.MemberType `xml:"source"`
+	DestinationAddresses *util.MemberType `xml:"destination"`
+	Sat                  *srcXlate        `xml:"source-translation"`
+	Dat                  *dstXlate        `xml:"destination-translation"`
+	Disabled             string           `xml:"disabled"`
+	Target               *targetInfo      `xml:"target"`
+	Tags                 *util.MemberType `xml:"tag"`
 }
 
 type dstXlate struct {
-    Address string `xml:"translated-address,omitempty"`
-    Port int `xml:"translated-port,omitempty"`
-    Distribution string `xml:"distribution,omitempty"`
+	Address      string `xml:"translated-address,omitempty"`
+	Port         int    `xml:"translated-port,omitempty"`
+	Distribution string `xml:"distribution,omitempty"`
 }
 
 type srcXlate struct {
-    Diap *srcXlateDiap `xml:"dynamic-ip-and-port"`
-    Di *srcXlateDi `xml:"dynamic-ip"`
-    Static *srcXlateStatic `xml:"static-ip"`
+	Diap   *srcXlateDiap   `xml:"dynamic-ip-and-port"`
+	Di     *srcXlateDi     `xml:"dynamic-ip"`
+	Static *srcXlateStatic `xml:"static-ip"`
 }
 
 type srcXlateDiap struct {
-    TranslatedAddress *util.MemberType `xml:"translated-address"`
-    InterfaceAddress *srcXlateDiapIa `xml:"interface-address"`
+	TranslatedAddress *util.MemberType `xml:"translated-address"`
+	InterfaceAddress  *srcXlateDiapIa  `xml:"interface-address"`
 }
 
 type srcXlateDiapIa struct {
-    Interface string `xml:"interface"`
-    Ip string `xml:"ip,omitempty"`
+	Interface string `xml:"interface"`
+	Ip        string `xml:"ip,omitempty"`
 }
 
 type srcXlateDi struct {
-    TranslatedAddress *util.MemberType `xml:"translated-address"`
-    Fallback *fallback `xml:"fallback"`
+	TranslatedAddress *util.MemberType `xml:"translated-address"`
+	Fallback          *fallback        `xml:"fallback"`
 }
 
 type fallback struct {
-    TranslatedAddress *util.MemberType `xml:"translated-address"`
-    InterfaceAddress *fallbackIface `xml:"interface-address"`
+	TranslatedAddress *util.MemberType `xml:"translated-address"`
+	InterfaceAddress  *fallbackIface   `xml:"interface-address"`
 }
 
 type fallbackIface struct {
-    Ip string `xml:"ip,omitempty"`
-    Interface string `xml:"interface,omitempty"`
-    FloatingIp string `xml:"floating-ip,omitempty"`
+	Ip         string `xml:"ip,omitempty"`
+	Interface  string `xml:"interface,omitempty"`
+	FloatingIp string `xml:"floating-ip,omitempty"`
 }
 
 type srcXlateStatic struct {
-    Address string `xml:"translated-address"`
-    BiDirectional string `xml:"bi-directional"`
+	Address       string `xml:"translated-address"`
+	BiDirectional string `xml:"bi-directional"`
 }
 
 type targetInfo struct {
-    Targets *util.VsysEntryType `xml:"devices"`
-    NegateTarget string `xml:"negate,omitempty"`
+	Targets      *util.VsysEntryType `xml:"devices"`
+	NegateTarget string              `xml:"negate,omitempty"`
 }
 
 func specify_v1(e Entry) interface{} {
-    ans := entry_v1{
-        Name: e.Name,
-        Description: e.Description,
-        Type: e.Type,
-        SourceZones: util.StrToMem(e.SourceZones),
-        DestinationZone: e.DestinationZone,
-        ToInterface: e.ToInterface,
-        Service: e.Service,
-        SourceAddresses: util.StrToMem(e.SourceAddresses),
-        DestinationAddresses: util.StrToMem(e.DestinationAddresses),
-        Disabled: util.YesNo(e.Disabled),
-        Tags: util.StrToMem(e.Tags),
-    }
+	ans := entry_v1{
+		Name:                 e.Name,
+		Description:          e.Description,
+		Type:                 e.Type,
+		SourceZones:          util.StrToMem(e.SourceZones),
+		DestinationZone:      e.DestinationZone,
+		ToInterface:          e.ToInterface,
+		Service:              e.Service,
+		SourceAddresses:      util.StrToMem(e.SourceAddresses),
+		DestinationAddresses: util.StrToMem(e.DestinationAddresses),
+		Disabled:             util.YesNo(e.Disabled),
+		Tags:                 util.StrToMem(e.Tags),
+	}
 
-    var sv *srcXlate
-    switch e.SatType {
-    case DynamicIpAndPort:
-        sv = &srcXlate{
-            Diap: &srcXlateDiap{},
-        }
-        switch e.SatAddressType {
-        case TranslatedAddress:
-            sv.Diap.TranslatedAddress = util.StrToMem(e.SatTranslatedAddresses)
-        case InterfaceAddress:
-            sv.Diap.InterfaceAddress = &srcXlateDiapIa{
-                Interface: e.SatInterface,
-                Ip: e.SatIpAddress,
-            }
-        }
-    case DynamicIp:
-        sv = &srcXlate{
-            Di: &srcXlateDi{
-                TranslatedAddress: util.StrToMem(e.SatTranslatedAddresses),
-            },
-        }
-        switch e.SatFallbackType {
-        case InterfaceAddress:
-            sv.Di.Fallback = &fallback{
-                InterfaceAddress: &fallbackIface{
-                    Interface: e.SatFallbackInterface,
-                },
-            }
-            switch e.SatFallbackIpType {
-            case Ip:
-                sv.Di.Fallback.InterfaceAddress.Ip = e.SatFallbackIpAddress
-            case FloatingIp:
-                sv.Di.Fallback.InterfaceAddress.FloatingIp = e.SatFallbackIpAddress
-            }
-        case TranslatedAddress:
-            sv.Di.Fallback = &fallback{TranslatedAddress: util.StrToMem(e.SatFallbackTranslatedAddresses)}
-        }
-    case StaticIp:
-        sv = &srcXlate{
-            Static: &srcXlateStatic{
-                e.SatStaticTranslatedAddress,
-                util.YesNo(e.SatStaticBiDirectional),
-            },
-        }
-    }
-    ans.Sat = sv
+	var sv *srcXlate
+	switch e.SatType {
+	case DynamicIpAndPort:
+		sv = &srcXlate{
+			Diap: &srcXlateDiap{},
+		}
+		switch e.SatAddressType {
+		case TranslatedAddress:
+			sv.Diap.TranslatedAddress = util.StrToMem(e.SatTranslatedAddresses)
+		case InterfaceAddress:
+			sv.Diap.InterfaceAddress = &srcXlateDiapIa{
+				Interface: e.SatInterface,
+				Ip:        e.SatIpAddress,
+			}
+		}
+	case DynamicIp:
+		sv = &srcXlate{
+			Di: &srcXlateDi{
+				TranslatedAddress: util.StrToMem(e.SatTranslatedAddresses),
+			},
+		}
+		switch e.SatFallbackType {
+		case InterfaceAddress:
+			sv.Di.Fallback = &fallback{
+				InterfaceAddress: &fallbackIface{
+					Interface: e.SatFallbackInterface,
+				},
+			}
+			switch e.SatFallbackIpType {
+			case Ip:
+				sv.Di.Fallback.InterfaceAddress.Ip = e.SatFallbackIpAddress
+			case FloatingIp:
+				sv.Di.Fallback.InterfaceAddress.FloatingIp = e.SatFallbackIpAddress
+			}
+		case TranslatedAddress:
+			sv.Di.Fallback = &fallback{TranslatedAddress: util.StrToMem(e.SatFallbackTranslatedAddresses)}
+		}
+	case StaticIp:
+		sv = &srcXlate{
+			Static: &srcXlateStatic{
+				e.SatStaticTranslatedAddress,
+				util.YesNo(e.SatStaticBiDirectional),
+			},
+		}
+	}
+	ans.Sat = sv
 
-    if e.DatType == DatTypeStatic {
-        if e.DatAddress != "" || e.DatPort != 0 {
-            ans.Dat = &dstXlate{
-                e.DatAddress,
-                e.DatPort,
-                "",
-            }
-        }
-    }
+	if e.DatType == DatTypeStatic {
+		if e.DatAddress != "" || e.DatPort != 0 {
+			ans.Dat = &dstXlate{
+				e.DatAddress,
+				e.DatPort,
+				"",
+			}
+		}
+	}
 
-    if len(e.Targets) != 0 || e.NegateTarget {
-        ans.Target = &targetInfo{
-            Targets: util.MapToVsysEnt(e.Targets),
-            NegateTarget: util.YesNo(e.NegateTarget),
-        }
-    }
+	if len(e.Targets) != 0 || e.NegateTarget {
+		ans.Target = &targetInfo{
+			Targets:      util.MapToVsysEnt(e.Targets),
+			NegateTarget: util.YesNo(e.NegateTarget),
+		}
+	}
 
-    return ans
+	return ans
 }
 
 type container_v2 struct {
-    Answer entry_v2 `xml:"result>entry"`
+	Answer entry_v2 `xml:"result>entry"`
 }
 
 func (o *container_v2) Normalize() Entry {
-    ans := Entry{
-        Name: o.Answer.Name,
-        Description: o.Answer.Description,
-        Type: o.Answer.Type,
-        SourceZones: util.MemToStr(o.Answer.SourceZones),
-        DestinationZone: o.Answer.DestinationZone,
-        ToInterface: o.Answer.ToInterface,
-        Service: o.Answer.Service,
-        SourceAddresses: util.MemToStr(o.Answer.SourceAddresses),
-        DestinationAddresses: util.MemToStr(o.Answer.DestinationAddresses),
-        Disabled: util.AsBool(o.Answer.Disabled),
-        Tags: util.MemToStr(o.Answer.Tags),
-    }
+	ans := Entry{
+		Name:                 o.Answer.Name,
+		Description:          o.Answer.Description,
+		Type:                 o.Answer.Type,
+		SourceZones:          util.MemToStr(o.Answer.SourceZones),
+		DestinationZone:      o.Answer.DestinationZone,
+		ToInterface:          o.Answer.ToInterface,
+		Service:              o.Answer.Service,
+		SourceAddresses:      util.MemToStr(o.Answer.SourceAddresses),
+		DestinationAddresses: util.MemToStr(o.Answer.DestinationAddresses),
+		Disabled:             util.AsBool(o.Answer.Disabled),
+		Tags:                 util.MemToStr(o.Answer.Tags),
+	}
 
-    if o.Answer.Sat == nil {
-        ans.SatType = None
-    } else {
-        switch {
-        case o.Answer.Sat.Diap != nil:
-            ans.SatType = DynamicIpAndPort
-            if o.Answer.Sat.Diap.InterfaceAddress != nil {
-                ans.SatAddressType = InterfaceAddress
-                ans.SatInterface = o.Answer.Sat.Diap.InterfaceAddress.Interface
-                ans.SatIpAddress = o.Answer.Sat.Diap.InterfaceAddress.Ip
-            } else {
-                ans.SatAddressType = TranslatedAddress
-                ans.SatTranslatedAddresses = util.MemToStr(o.Answer.Sat.Diap.TranslatedAddress)
-            }
-        case o.Answer.Sat.Di != nil:
-            ans.SatType = DynamicIp
-            ans.SatTranslatedAddresses = util.MemToStr(o.Answer.Sat.Di.TranslatedAddress)
-            if o.Answer.Sat.Di.Fallback == nil {
-                ans.SatFallbackType = None
-            } else if o.Answer.Sat.Di.Fallback.TranslatedAddress != nil {
-                ans.SatFallbackType = TranslatedAddress
-                ans.SatFallbackTranslatedAddresses = util.MemToStr(o.Answer.Sat.Di.Fallback.TranslatedAddress)
-            } else if o.Answer.Sat.Di.Fallback.InterfaceAddress != nil {
-                ans.SatFallbackType = InterfaceAddress
-                ans.SatFallbackInterface = o.Answer.Sat.Di.Fallback.InterfaceAddress.Interface
-                if o.Answer.Sat.Di.Fallback.InterfaceAddress.Ip != "" {
-                    ans.SatFallbackIpType = Ip
-                    ans.SatFallbackIpAddress = o.Answer.Sat.Di.Fallback.InterfaceAddress.Ip
-                } else if o.Answer.Sat.Di.Fallback.InterfaceAddress.FloatingIp != "" {
-                    ans.SatFallbackIpType = FloatingIp
-                    ans.SatFallbackIpAddress = o.Answer.Sat.Di.Fallback.InterfaceAddress.FloatingIp
-                }
-            }
-        case o.Answer.Sat.Static != nil:
-            ans.SatType = StaticIp
-            ans.SatStaticTranslatedAddress = o.Answer.Sat.Static.Address
-            ans.SatStaticBiDirectional = util.AsBool(o.Answer.Sat.Static.BiDirectional)
-        }
-    }
+	if o.Answer.Sat == nil {
+		ans.SatType = None
+	} else {
+		switch {
+		case o.Answer.Sat.Diap != nil:
+			ans.SatType = DynamicIpAndPort
+			if o.Answer.Sat.Diap.InterfaceAddress != nil {
+				ans.SatAddressType = InterfaceAddress
+				ans.SatInterface = o.Answer.Sat.Diap.InterfaceAddress.Interface
+				ans.SatIpAddress = o.Answer.Sat.Diap.InterfaceAddress.Ip
+			} else {
+				ans.SatAddressType = TranslatedAddress
+				ans.SatTranslatedAddresses = util.MemToStr(o.Answer.Sat.Diap.TranslatedAddress)
+			}
+		case o.Answer.Sat.Di != nil:
+			ans.SatType = DynamicIp
+			ans.SatTranslatedAddresses = util.MemToStr(o.Answer.Sat.Di.TranslatedAddress)
+			if o.Answer.Sat.Di.Fallback == nil {
+				ans.SatFallbackType = None
+			} else if o.Answer.Sat.Di.Fallback.TranslatedAddress != nil {
+				ans.SatFallbackType = TranslatedAddress
+				ans.SatFallbackTranslatedAddresses = util.MemToStr(o.Answer.Sat.Di.Fallback.TranslatedAddress)
+			} else if o.Answer.Sat.Di.Fallback.InterfaceAddress != nil {
+				ans.SatFallbackType = InterfaceAddress
+				ans.SatFallbackInterface = o.Answer.Sat.Di.Fallback.InterfaceAddress.Interface
+				if o.Answer.Sat.Di.Fallback.InterfaceAddress.Ip != "" {
+					ans.SatFallbackIpType = Ip
+					ans.SatFallbackIpAddress = o.Answer.Sat.Di.Fallback.InterfaceAddress.Ip
+				} else if o.Answer.Sat.Di.Fallback.InterfaceAddress.FloatingIp != "" {
+					ans.SatFallbackIpType = FloatingIp
+					ans.SatFallbackIpAddress = o.Answer.Sat.Di.Fallback.InterfaceAddress.FloatingIp
+				}
+			}
+		case o.Answer.Sat.Static != nil:
+			ans.SatType = StaticIp
+			ans.SatStaticTranslatedAddress = o.Answer.Sat.Static.Address
+			ans.SatStaticBiDirectional = util.AsBool(o.Answer.Sat.Static.BiDirectional)
+		}
+	}
 
-    if o.Answer.Dat != nil {
-        ans.DatType = DatTypeStatic
-        ans.DatAddress = o.Answer.Dat.Address
-        ans.DatPort = o.Answer.Dat.Port
-    }
+	if o.Answer.Dat != nil {
+		ans.DatType = DatTypeStatic
+		ans.DatAddress = o.Answer.Dat.Address
+		ans.DatPort = o.Answer.Dat.Port
+	}
 
-    if o.Answer.DatDynamic != nil {
-        ans.DatType = DatTypeDynamic
-        ans.DatAddress = o.Answer.DatDynamic.Address
-        ans.DatPort = o.Answer.DatDynamic.Port
-        ans.DatDynamicDistribution = o.Answer.DatDynamic.Distribution
-    }
+	if o.Answer.DatDynamic != nil {
+		ans.DatType = DatTypeDynamic
+		ans.DatAddress = o.Answer.DatDynamic.Address
+		ans.DatPort = o.Answer.DatDynamic.Port
+		ans.DatDynamicDistribution = o.Answer.DatDynamic.Distribution
+	}
 
-    if o.Answer.Target != nil {
-        ans.Targets = util.VsysEntToMap(o.Answer.Target.Targets)
-        ans.NegateTarget = util.AsBool(o.Answer.Target.NegateTarget)
-    }
+	if o.Answer.Target != nil {
+		ans.Targets = util.VsysEntToMap(o.Answer.Target.Targets)
+		ans.NegateTarget = util.AsBool(o.Answer.Target.NegateTarget)
+	}
 
-    return ans
+	return ans
 }
 
 type entry_v2 struct {
-    XMLName xml.Name `xml:"entry"`
-    Name string `xml:"name,attr"`
-    Description string `xml:"description"`
-    Type string `xml:"nat-type"`
-    SourceZones *util.MemberType `xml:"from"`
-    DestinationZone string `xml:"to>member"`
-    ToInterface string `xml:"to-interface"`
-    Service string `xml:"service"`
-    SourceAddresses *util.MemberType `xml:"source"`
-    DestinationAddresses *util.MemberType `xml:"destination"`
-    Sat *srcXlate `xml:"source-translation"`
-    Dat *dstXlate `xml:"destination-translation"`
-    DatDynamic *dstXlate `xml:"dynamic-destination-translation"`
-    Disabled string `xml:"disabled"`
-    Target *targetInfo `xml:"target"`
-    Tags *util.MemberType `xml:"tag"`
+	XMLName              xml.Name         `xml:"entry"`
+	Name                 string           `xml:"name,attr"`
+	Description          string           `xml:"description"`
+	Type                 string           `xml:"nat-type"`
+	SourceZones          *util.MemberType `xml:"from"`
+	DestinationZone      string           `xml:"to>member"`
+	ToInterface          string           `xml:"to-interface"`
+	Service              string           `xml:"service"`
+	SourceAddresses      *util.MemberType `xml:"source"`
+	DestinationAddresses *util.MemberType `xml:"destination"`
+	Sat                  *srcXlate        `xml:"source-translation"`
+	Dat                  *dstXlate        `xml:"destination-translation"`
+	DatDynamic           *dstXlate        `xml:"dynamic-destination-translation"`
+	Disabled             string           `xml:"disabled"`
+	Target               *targetInfo      `xml:"target"`
+	Tags                 *util.MemberType `xml:"tag"`
 }
 
 func specify_v2(e Entry) interface{} {
-    ans := entry_v2{
-        Name: e.Name,
-        Description: e.Description,
-        Type: e.Type,
-        SourceZones: util.StrToMem(e.SourceZones),
-        DestinationZone: e.DestinationZone,
-        ToInterface: e.ToInterface,
-        Service: e.Service,
-        SourceAddresses: util.StrToMem(e.SourceAddresses),
-        DestinationAddresses: util.StrToMem(e.DestinationAddresses),
-        Disabled: util.YesNo(e.Disabled),
-        Tags: util.StrToMem(e.Tags),
-    }
+	ans := entry_v2{
+		Name:                 e.Name,
+		Description:          e.Description,
+		Type:                 e.Type,
+		SourceZones:          util.StrToMem(e.SourceZones),
+		DestinationZone:      e.DestinationZone,
+		ToInterface:          e.ToInterface,
+		Service:              e.Service,
+		SourceAddresses:      util.StrToMem(e.SourceAddresses),
+		DestinationAddresses: util.StrToMem(e.DestinationAddresses),
+		Disabled:             util.YesNo(e.Disabled),
+		Tags:                 util.StrToMem(e.Tags),
+	}
 
-    var sv *srcXlate
-    switch e.SatType {
-    case DynamicIpAndPort:
-        sv = &srcXlate{
-            Diap: &srcXlateDiap{},
-        }
-        switch e.SatAddressType {
-        case TranslatedAddress:
-            sv.Diap.TranslatedAddress = util.StrToMem(e.SatTranslatedAddresses)
-        case InterfaceAddress:
-            sv.Diap.InterfaceAddress = &srcXlateDiapIa{
-                Interface: e.SatInterface,
-                Ip: e.SatIpAddress,
-            }
-        }
-    case DynamicIp:
-        sv = &srcXlate{
-            Di: &srcXlateDi{
-                TranslatedAddress: util.StrToMem(e.SatTranslatedAddresses),
-            },
-        }
-        switch e.SatFallbackType {
-        case InterfaceAddress:
-            sv.Di.Fallback = &fallback{
-                InterfaceAddress: &fallbackIface{
-                    Interface: e.SatFallbackInterface,
-                },
-            }
-            switch e.SatFallbackIpType {
-            case Ip:
-                sv.Di.Fallback.InterfaceAddress.Ip = e.SatFallbackIpAddress
-            case FloatingIp:
-                sv.Di.Fallback.InterfaceAddress.FloatingIp = e.SatFallbackIpAddress
-            }
-        case TranslatedAddress:
-            sv.Di.Fallback = &fallback{TranslatedAddress: util.StrToMem(e.SatFallbackTranslatedAddresses)}
-        }
-    case StaticIp:
-        sv = &srcXlate{
-            Static: &srcXlateStatic{
-                e.SatStaticTranslatedAddress,
-                util.YesNo(e.SatStaticBiDirectional),
-            },
-        }
-    }
-    ans.Sat = sv
+	var sv *srcXlate
+	switch e.SatType {
+	case DynamicIpAndPort:
+		sv = &srcXlate{
+			Diap: &srcXlateDiap{},
+		}
+		switch e.SatAddressType {
+		case TranslatedAddress:
+			sv.Diap.TranslatedAddress = util.StrToMem(e.SatTranslatedAddresses)
+		case InterfaceAddress:
+			sv.Diap.InterfaceAddress = &srcXlateDiapIa{
+				Interface: e.SatInterface,
+				Ip:        e.SatIpAddress,
+			}
+		}
+	case DynamicIp:
+		sv = &srcXlate{
+			Di: &srcXlateDi{
+				TranslatedAddress: util.StrToMem(e.SatTranslatedAddresses),
+			},
+		}
+		switch e.SatFallbackType {
+		case InterfaceAddress:
+			sv.Di.Fallback = &fallback{
+				InterfaceAddress: &fallbackIface{
+					Interface: e.SatFallbackInterface,
+				},
+			}
+			switch e.SatFallbackIpType {
+			case Ip:
+				sv.Di.Fallback.InterfaceAddress.Ip = e.SatFallbackIpAddress
+			case FloatingIp:
+				sv.Di.Fallback.InterfaceAddress.FloatingIp = e.SatFallbackIpAddress
+			}
+		case TranslatedAddress:
+			sv.Di.Fallback = &fallback{TranslatedAddress: util.StrToMem(e.SatFallbackTranslatedAddresses)}
+		}
+	case StaticIp:
+		sv = &srcXlate{
+			Static: &srcXlateStatic{
+				e.SatStaticTranslatedAddress,
+				util.YesNo(e.SatStaticBiDirectional),
+			},
+		}
+	}
+	ans.Sat = sv
 
-    if e.DatType == DatTypeStatic {
-        if e.DatAddress != "" || e.DatPort != 0 {
-            ans.Dat = &dstXlate{
-                e.DatAddress,
-                e.DatPort,
-                "",
-            }
-        }
-    } else if e.DatType == DatTypeDynamic {
-        if e.DatAddress != "" || e.DatPort != 0 || e.DatDynamicDistribution != "" {
-            ans.DatDynamic = &dstXlate{
-                e.DatAddress,
-                e.DatPort,
-                e.DatDynamicDistribution,
-            }
-        }
-    }
+	if e.DatType == DatTypeStatic {
+		if e.DatAddress != "" || e.DatPort != 0 {
+			ans.Dat = &dstXlate{
+				e.DatAddress,
+				e.DatPort,
+				"",
+			}
+		}
+	} else if e.DatType == DatTypeDynamic {
+		if e.DatAddress != "" || e.DatPort != 0 || e.DatDynamicDistribution != "" {
+			ans.DatDynamic = &dstXlate{
+				e.DatAddress,
+				e.DatPort,
+				e.DatDynamicDistribution,
+			}
+		}
+	}
 
-    if len(e.Targets) != 0 || e.NegateTarget {
-        ans.Target = &targetInfo{
-            Targets: util.MapToVsysEnt(e.Targets),
-            NegateTarget: util.YesNo(e.NegateTarget),
-        }
-    }
+	if len(e.Targets) != 0 || e.NegateTarget {
+		ans.Target = &targetInfo{
+			Targets:      util.MapToVsysEnt(e.Targets),
+			NegateTarget: util.YesNo(e.NegateTarget),
+		}
+	}
 
-    return ans
+	return ans
+}
+
+//EntryContainerMulti container for full list of nat policies
+type EntryContainerMulti struct {
+	Entries []Entry `xml:"response>result>rulebase>nat>rules>entry"`
+}
+
+//UnmarshalXML parses raw result for the rulebase xml tree
+func (e *EntryContainerMulti) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for {
+		token, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch childToken := token.(type) {
+		case xml.StartElement:
+			switch childToken.Name.Local {
+			case "entry":
+				entry := entry_v1{}
+				err = d.DecodeElement(&entry, &childToken)
+				if err != nil {
+					return err
+				}
+				containerized := container_v1{entry}
+				e.Entries = append(e.Entries, containerized.Normalize())
+			}
+		case xml.EndElement:
+			if childToken == start.End() {
+				return nil
+			}
+		}
+	}
 }

--- a/poli/nat/fw.go
+++ b/poli/nat/fw.go
@@ -1,233 +1,257 @@
 package nat
 
 import (
-    "fmt"
-    "encoding/xml"
-    "strings"
+	"encoding/xml"
+	"fmt"
+	"strings"
 
-    "github.com/PaloAltoNetworks/pango/util"
-    "github.com/PaloAltoNetworks/pango/version"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
 )
 
 // FwNat is the client.Policies.Nat namespace.
 type FwNat struct {
-    con util.XapiClient
+	con util.XapiClient
 }
 
 // Initialize is invoed by client.Initialize().
 func (c *FwNat) Initialize(con util.XapiClient) {
-    c.con = con
+	c.con = con
 }
 
 // GetList performs GET to retrieve a list of NAT policies.
 func (c *FwNat) GetList(vsys string) ([]string, error) {
-    c.con.LogQuery("(get) list of %s", plural)
-    path := c.xpath(vsys, nil)
-    return c.con.EntryListUsing(c.con.Get, path[:len(path) - 1])
+	c.con.LogQuery("(get) list of %s", plural)
+	path := c.xpath(vsys, nil)
+	return c.con.EntryListUsing(c.con.Get, path[:len(path)-1])
 }
 
-// ShowList performs SHOW to retrieve a list of NAT policies.
+// GetFullList performs GET to retreive a list of security policies
+func (c *FwNat) GetFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(get) list of service objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
+}
+
+// ShowList performs SHOW to retrieve a list of security policies.
 func (c *FwNat) ShowList(vsys string) ([]string, error) {
-    c.con.LogQuery("(show) list of %s", plural)
-    path := c.xpath(vsys, nil)
-    return c.con.EntryListUsing(c.con.Show, path[:len(path) - 1])
+	c.con.LogQuery("(show) list of security policies")
+	path := c.xpath(vsys, nil)
+	return c.con.EntryListUsing(c.con.Show, path[:len(path)-1])
+}
+
+// ShowFullList performs SHOW to retreive a list of security policies
+func (c *FwNat) ShowFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(show) list of service objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // Get performs GET to retrieve information for the given NAT policy.
 func (c *FwNat) Get(vsys, name string) (Entry, error) {
-    c.con.LogQuery("(get) %s %q", singular, name)
-    return c.details(c.con.Get, vsys, name)
+	c.con.LogQuery("(get) %s %q", singular, name)
+	return c.details(c.con.Get, vsys, name)
 }
 
 // Get performs SHOW to retrieve information for the given NAT policy.
 func (c *FwNat) Show(vsys, name string) (Entry, error) {
-    c.con.LogQuery("(show) %s %q", singular, name)
-    return c.details(c.con.Show, vsys, name)
+	c.con.LogQuery("(show) %s %q", singular, name)
+	return c.details(c.con.Show, vsys, name)
 }
 
 // Set performs SET to create / update one or more NAT policies.
 func (c *FwNat) Set(vsys string, e ...Entry) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    } else {
-        // Make sure rule names are unique.
-        m := make(map[string] int)
-        for i := range e {
-            m[e[i].Name] = m[e[i].Name] + 1
-            if m[e[i].Name] > 1 {
-                return fmt.Errorf("NAT rule is defined multiple times: %s", e[i].Name)
-            }
-        }
-    }
+	if len(e) == 0 {
+		return nil
+	} else {
+		// Make sure rule names are unique.
+		m := make(map[string]int)
+		for i := range e {
+			m[e[i].Name] = m[e[i].Name] + 1
+			if m[e[i].Name] > 1 {
+				return fmt.Errorf("NAT rule is defined multiple times: %s", e[i].Name)
+			}
+		}
+	}
 
-    _, fn := c.versioning()
-    names := make([]string, len(e))
+	_, fn := c.versioning()
+	names := make([]string, len(e))
 
-    // Build up the struct with the given configs.
-    d := util.BulkElement{XMLName: xml.Name{Local: "rules"}}
-    for i := range e {
-        d.Data = append(d.Data, fn(e[i]))
-        names[i] = e[i].Name
-    }
-    c.con.LogAction("(set) %s: %v", plural, names)
+	// Build up the struct with the given configs.
+	d := util.BulkElement{XMLName: xml.Name{Local: "rules"}}
+	for i := range e {
+		d.Data = append(d.Data, fn(e[i]))
+		names[i] = e[i].Name
+	}
+	c.con.LogAction("(set) %s: %v", plural, names)
 
-    // Set xpath.
-    path := c.xpath(vsys, names)
-    if len(e) == 1 {
-        path = path[:len(path) - 1]
-    } else {
-        path = path[:len(path) - 2]
-    }
+	// Set xpath.
+	path := c.xpath(vsys, names)
+	if len(e) == 1 {
+		path = path[:len(path)-1]
+	} else {
+		path = path[:len(path)-2]
+	}
 
-    // Create the NAT policies.
-    _, err = c.con.Set(path, d.Config(), nil, nil)
+	// Create the NAT policies.
+	_, err = c.con.Set(path, d.Config(), nil, nil)
 
-    // On error: find the rule that's causing the error if multiple rules
-    // were given.
-    if err != nil && strings.Contains(err.Error(), "rules is invalid") {
-        for i := 0; i < len(e); i++ {
-            if e2 := c.Set(vsys, e[i]); e2 != nil {
-                return fmt.Errorf("Error with rule %d: %s", i + 1, e2)
-            } else {
-                _ = c.Delete(vsys, e[i])
-            }
-        }
+	// On error: find the rule that's causing the error if multiple rules
+	// were given.
+	if err != nil && strings.Contains(err.Error(), "rules is invalid") {
+		for i := 0; i < len(e); i++ {
+			if e2 := c.Set(vsys, e[i]); e2 != nil {
+				return fmt.Errorf("Error with rule %d: %s", i+1, e2)
+			} else {
+				_ = c.Delete(vsys, e[i])
+			}
+		}
 
-        // Couldn't find it, just return the original error.
-        return err
-    }
+		// Couldn't find it, just return the original error.
+		return err
+	}
 
-    return err
+	return err
 }
 
 // Edit performs EDIT to create / update a NAT policy.
 func (c *FwNat) Edit(vsys string, e Entry) error {
-    var err error
+	var err error
 
-    _, fn := c.versioning()
+	_, fn := c.versioning()
 
-    c.con.LogAction("(edit) %s %q", singular, e.Name)
+	c.con.LogAction("(edit) %s %q", singular, e.Name)
 
-    // Set xpath.
-    path := c.xpath(vsys, []string{e.Name})
+	// Set xpath.
+	path := c.xpath(vsys, []string{e.Name})
 
-    // Edit the NAT policy.
-    _, err = c.con.Edit(path, fn(e), nil, nil)
-    return err
+	// Edit the NAT policy.
+	_, err = c.con.Edit(path, fn(e), nil, nil)
+	return err
 }
 
 // Delete removes the given NAT policies.
 //
 // NAT policies can be either a string or an Entry object.
 func (c *FwNat) Delete(vsys string, e ...interface{}) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    names := make([]string, len(e))
-    for i := range e {
-        switch v := e[i].(type) {
-        case string:
-            names[i] = v
-        case Entry:
-            names[i] = v.Name
-        default:
-            return fmt.Errorf("Unsupported type to delete: %s", v)
-        }
-    }
-    c.con.LogAction("(delete) %s: %v", plural, names)
+	names := make([]string, len(e))
+	for i := range e {
+		switch v := e[i].(type) {
+		case string:
+			names[i] = v
+		case Entry:
+			names[i] = v.Name
+		default:
+			return fmt.Errorf("Unsupported type to delete: %s", v)
+		}
+	}
+	c.con.LogAction("(delete) %s: %v", plural, names)
 
-    path := c.xpath(vsys, names)
-    _, err = c.con.Delete(path, nil, nil)
-    return err
+	path := c.xpath(vsys, names)
+	_, err = c.con.Delete(path, nil, nil)
+	return err
 }
 
 // MoveGroup moves a logical group of NAT rules somewhere in relation
 // to another rule.
 func (c *FwNat) MoveGroup(vsys string, mvt int, rule string, e ...Entry) error {
-    var err error
+	var err error
 
-    c.con.LogAction("(move) %s group", singular)
+	c.con.LogAction("(move) %s group", singular)
 
-    if len(e) < 1 {
-        return fmt.Errorf("Requires at least one rule")
-    }
+	if len(e) < 1 {
+		return fmt.Errorf("Requires at least one rule")
+	}
 
-    path := c.xpath(vsys, []string{e[0].Name})
-    list, err := c.GetList(vsys)
-    if err != nil {
-        return err
-    }
+	path := c.xpath(vsys, []string{e[0].Name})
+	list, err := c.GetList(vsys)
+	if err != nil {
+		return err
+	}
 
-    // Set the first entity's position.
-    if err = c.con.PositionFirstEntity(mvt, rule, e[0].Name, path, list); err != nil {
-        return err
-    }
+	// Set the first entity's position.
+	if err = c.con.PositionFirstEntity(mvt, rule, e[0].Name, path, list); err != nil {
+		return err
+	}
 
-    // Move all the rest under it.
-    li := len(path) - 1
-    for i := 1; i < len(e); i++ {
-        path[li] = util.AsEntryXpath([]string{e[i].Name})
-        if _, err = c.con.Move(path, "after", e[i - 1].Name, nil, nil); err != nil {
-            return err
-        }
-    }
+	// Move all the rest under it.
+	li := len(path) - 1
+	for i := 1; i < len(e); i++ {
+		path[li] = util.AsEntryXpath([]string{e[i].Name})
+		if _, err = c.con.Move(path, "after", e[i-1].Name, nil, nil); err != nil {
+			return err
+		}
+	}
 
-    return nil
+	return nil
 }
 
 /** Internal functions for the Zone struct **/
 
-func (c *FwNat) versioning() (normalizer, func(Entry) (interface{})) {
-    v := c.con.Versioning()
+func (c *FwNat) versioning() (normalizer, func(Entry) interface{}) {
+	v := c.con.Versioning()
 
-    if v.Gte(version.Number{8, 1, 0, ""}) {
-        return &container_v2{}, specify_v2
-    } else {
-        return &container_v1{}, specify_v1
-    }
+	if v.Gte(version.Number{8, 1, 0, ""}) {
+		return &container_v2{}, specify_v2
+	} else {
+		return &container_v1{}, specify_v1
+	}
 }
 
 func (c *FwNat) details(fn util.Retriever, vsys, name string) (Entry, error) {
-    path := c.xpath(vsys, []string{name})
-    obj, _ := c.versioning()
-    if _, err := fn(path, nil, obj); err != nil {
-        return Entry{}, err
-    }
-    ans := obj.Normalize()
+	path := c.xpath(vsys, []string{name})
+	obj, _ := c.versioning()
+	if _, err := fn(path, nil, obj); err != nil {
+		return Entry{}, err
+	}
+	ans := obj.Normalize()
 
-    return ans, nil
+	return ans, nil
 }
 
 func (c *FwNat) xpath(vsys string, vals []string) []string {
-    if vsys == "" {
-        vsys = "vsys1"
-    }
+	if vsys == "" {
+		vsys = "vsys1"
+	}
 
-    if vsys == "shared" {
-        return []string{
-            "config",
-            "shared",
-            "rulebase",
-            "nat",
-            "rules",
-            util.AsEntryXpath(vals),
-        }
-    }
+	if vsys == "shared" {
+		return []string{
+			"config",
+			"shared",
+			"rulebase",
+			"nat",
+			"rules",
+			util.AsEntryXpath(vals),
+		}
+	}
 
-    return []string{
-        "config",
-        "devices",
-        util.AsEntryXpath([]string{"localhost.localdomain"}),
-        "vsys",
-        util.AsEntryXpath([]string{vsys}),
-        "rulebase",
-        "nat",
-        "rules",
-        util.AsEntryXpath(vals),
-    }
+	return []string{
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"vsys",
+		util.AsEntryXpath([]string{vsys}),
+		"rulebase",
+		"nat",
+		"rules",
+		util.AsEntryXpath(vals),
+	}
 }

--- a/poli/nat/pano.go
+++ b/poli/nat/pano.go
@@ -1,236 +1,260 @@
 package nat
 
 import (
-    "fmt"
-    "encoding/xml"
-    "strings"
+	"encoding/xml"
+	"fmt"
+	"strings"
 
-    "github.com/PaloAltoNetworks/pango/util"
-    "github.com/PaloAltoNetworks/pango/version"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
 )
 
 // PanoNat is the client.Policies.Nat namespace.
 type PanoNat struct {
-    con util.XapiClient
+	con util.XapiClient
 }
 
 // Initialize is invoed by client.Initialize().
 func (c *PanoNat) Initialize(con util.XapiClient) {
-    c.con = con
+	c.con = con
 }
 
 // GetList performs GET to retrieve a list of NAT policies.
 func (c *PanoNat) GetList(dg, base string) ([]string, error) {
-    c.con.LogQuery("(get) list of %s", plural)
-    path := c.xpath(dg, base, nil)
-    return c.con.EntryListUsing(c.con.Get, path[:len(path) - 1])
+	c.con.LogQuery("(get) list of %s", plural)
+	path := c.xpath(dg, base, nil)
+	return c.con.EntryListUsing(c.con.Get, path[:len(path)-1])
 }
 
-// ShowList performs SHOW to retrieve a list of NAT policies.
+// GetFullList performs GET to retreive a list of security policies
+func (c *PanoNat) GetFullList(dg, base string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(get) list of service objects")
+	path := c.xpath(dg, base, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
+}
+
+// ShowList performs SHOW to retrieve a list of security policies.
 func (c *PanoNat) ShowList(dg, base string) ([]string, error) {
-    c.con.LogQuery("(show) list of %s", plural)
-    path := c.xpath(dg, base, nil)
-    return c.con.EntryListUsing(c.con.Show, path[:len(path) - 1])
+	c.con.LogQuery("(show) list of security policies")
+	path := c.xpath(dg, base, nil)
+	return c.con.EntryListUsing(c.con.Show, path[:len(path)-1])
+}
+
+// ShowFullList performs SHOW to retreive a list of security policies
+func (c *PanoNat) ShowFullList(dg, base string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(show) list of service objects")
+	path := c.xpath(dg, base, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // Get performs GET to retrieve information for the given NAT policy.
 func (c *PanoNat) Get(dg, base, name string) (Entry, error) {
-    c.con.LogQuery("(get) %s %q", singular, name)
-    return c.details(c.con.Get, dg, base, name)
+	c.con.LogQuery("(get) %s %q", singular, name)
+	return c.details(c.con.Get, dg, base, name)
 }
 
 // Get performs SHOW to retrieve information for the given NAT policy.
 func (c *PanoNat) Show(dg, base, name string) (Entry, error) {
-    c.con.LogQuery("(show) %s %q", singular, name)
-    return c.details(c.con.Show, dg, base, name)
+	c.con.LogQuery("(show) %s %q", singular, name)
+	return c.details(c.con.Show, dg, base, name)
 }
 
 // Set performs SET to create / update one or more NAT policies.
 func (c *PanoNat) Set(dg, base string, e ...Entry) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    } else {
-        // Make sure rule names are unique.
-        m := make(map[string] int)
-        for i := range e {
-            m[e[i].Name] = m[e[i].Name] + 1
-            if m[e[i].Name] > 1 {
-                return fmt.Errorf("NAT rule is defined multiple times: %s", e[i].Name)
-            }
-        }
-    }
+	if len(e) == 0 {
+		return nil
+	} else {
+		// Make sure rule names are unique.
+		m := make(map[string]int)
+		for i := range e {
+			m[e[i].Name] = m[e[i].Name] + 1
+			if m[e[i].Name] > 1 {
+				return fmt.Errorf("NAT rule is defined multiple times: %s", e[i].Name)
+			}
+		}
+	}
 
-    _, fn := c.versioning()
-    names := make([]string, len(e))
+	_, fn := c.versioning()
+	names := make([]string, len(e))
 
-    // Build up the struct with the given configs.
-    d := util.BulkElement{XMLName: xml.Name{Local: "rules"}}
-    for i := range e {
-        d.Data = append(d.Data, fn(e[i]))
-        names[i] = e[i].Name
-    }
-    c.con.LogAction("(set) %s: %v", plural, names)
+	// Build up the struct with the given configs.
+	d := util.BulkElement{XMLName: xml.Name{Local: "rules"}}
+	for i := range e {
+		d.Data = append(d.Data, fn(e[i]))
+		names[i] = e[i].Name
+	}
+	c.con.LogAction("(set) %s: %v", plural, names)
 
-    // Set xpath.
-    path := c.xpath(dg, base, names)
-    if len(e) == 1 {
-        path = path[:len(path) - 1]
-    } else {
-        path = path[:len(path) - 2]
-    }
+	// Set xpath.
+	path := c.xpath(dg, base, names)
+	if len(e) == 1 {
+		path = path[:len(path)-1]
+	} else {
+		path = path[:len(path)-2]
+	}
 
-    // Create the NAT policies.
-    _, err = c.con.Set(path, d.Config(), nil, nil)
+	// Create the NAT policies.
+	_, err = c.con.Set(path, d.Config(), nil, nil)
 
-    // On error: find the rule that's causing the error if multiple rules
-    // were given.
-    if err != nil && strings.Contains(err.Error(), "rules is invalid") {
-        for i := 0; i < len(e); i++ {
-            if e2 := c.Set(dg, base, e[i]); e2 != nil {
-                return fmt.Errorf("Error with rule %d: %s", i + 1, e2)
-            } else {
-                _ = c.Delete(dg, base, e[i])
-            }
-        }
+	// On error: find the rule that's causing the error if multiple rules
+	// were given.
+	if err != nil && strings.Contains(err.Error(), "rules is invalid") {
+		for i := 0; i < len(e); i++ {
+			if e2 := c.Set(dg, base, e[i]); e2 != nil {
+				return fmt.Errorf("Error with rule %d: %s", i+1, e2)
+			} else {
+				_ = c.Delete(dg, base, e[i])
+			}
+		}
 
-        // Couldn't find it, just return the original error.
-        return err
-    }
+		// Couldn't find it, just return the original error.
+		return err
+	}
 
-    return err
+	return err
 }
 
 // Edit performs EDIT to create / update a NAT policy.
 func (c *PanoNat) Edit(dg, base string, e Entry) error {
-    var err error
+	var err error
 
-    _, fn := c.versioning()
+	_, fn := c.versioning()
 
-    c.con.LogAction("(edit) %s %q", singular, e.Name)
+	c.con.LogAction("(edit) %s %q", singular, e.Name)
 
-    // Set xpath.
-    path := c.xpath(dg, base, []string{e.Name})
+	// Set xpath.
+	path := c.xpath(dg, base, []string{e.Name})
 
-    // Edit the NAT policy.
-    _, err = c.con.Edit(path, fn(e), nil, nil)
-    return err
+	// Edit the NAT policy.
+	_, err = c.con.Edit(path, fn(e), nil, nil)
+	return err
 }
 
 // Delete removes the given NAT policies.
 //
 // NAT policies can be either a string or an Entry object.
 func (c *PanoNat) Delete(dg, base string, e ...interface{}) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    names := make([]string, len(e))
-    for i := range e {
-        switch v := e[i].(type) {
-        case string:
-            names[i] = v
-        case Entry:
-            names[i] = v.Name
-        default:
-            return fmt.Errorf("Unsupported type to delete: %s", v)
-        }
-    }
-    c.con.LogAction("(delete) %s: %v", plural, names)
+	names := make([]string, len(e))
+	for i := range e {
+		switch v := e[i].(type) {
+		case string:
+			names[i] = v
+		case Entry:
+			names[i] = v.Name
+		default:
+			return fmt.Errorf("Unsupported type to delete: %s", v)
+		}
+	}
+	c.con.LogAction("(delete) %s: %v", plural, names)
 
-    path := c.xpath(dg, base, names)
-    _, err = c.con.Delete(path, nil, nil)
-    return err
+	path := c.xpath(dg, base, names)
+	_, err = c.con.Delete(path, nil, nil)
+	return err
 }
 
 // MoveGroup moves a logical group of NAT rules somewhere in relation
 // to another rule.
 func (c *PanoNat) MoveGroup(dg, base string, mvt int, rule string, e ...Entry) error {
-    var err error
+	var err error
 
-    c.con.LogAction("(move) %s group", singular)
+	c.con.LogAction("(move) %s group", singular)
 
-    if len(e) < 1 {
-        return fmt.Errorf("Requires at least one rule")
-    }
+	if len(e) < 1 {
+		return fmt.Errorf("Requires at least one rule")
+	}
 
-    path := c.xpath(dg, base, []string{e[0].Name})
-    list, err := c.GetList(dg, base)
-    if err != nil {
-        return err
-    }
+	path := c.xpath(dg, base, []string{e[0].Name})
+	list, err := c.GetList(dg, base)
+	if err != nil {
+		return err
+	}
 
-    // Set the first entity's position.
-    if err = c.con.PositionFirstEntity(mvt, rule, e[0].Name, path, list); err != nil {
-        return err
-    }
+	// Set the first entity's position.
+	if err = c.con.PositionFirstEntity(mvt, rule, e[0].Name, path, list); err != nil {
+		return err
+	}
 
-    // Move all the rest under it.
-    li := len(path) - 1
-    for i := 1; i < len(e); i++ {
-        path[li] = util.AsEntryXpath([]string{e[i].Name})
-        if _, err = c.con.Move(path, "after", e[i - 1].Name, nil, nil); err != nil {
-            return err
-        }
-    }
+	// Move all the rest under it.
+	li := len(path) - 1
+	for i := 1; i < len(e); i++ {
+		path[li] = util.AsEntryXpath([]string{e[i].Name})
+		if _, err = c.con.Move(path, "after", e[i-1].Name, nil, nil); err != nil {
+			return err
+		}
+	}
 
-    return nil
+	return nil
 }
 
 /** Internal functions for the Zone struct **/
 
-func (c *PanoNat) versioning() (normalizer, func(Entry) (interface{})) {
-    v := c.con.Versioning()
+func (c *PanoNat) versioning() (normalizer, func(Entry) interface{}) {
+	v := c.con.Versioning()
 
-    if v.Gte(version.Number{8, 1, 0, ""}) {
-        return &container_v2{}, specify_v2
-    } else {
-        return &container_v1{}, specify_v1
-    }
+	if v.Gte(version.Number{8, 1, 0, ""}) {
+		return &container_v2{}, specify_v2
+	} else {
+		return &container_v1{}, specify_v1
+	}
 }
 
 func (c *PanoNat) details(fn util.Retriever, dg, base, name string) (Entry, error) {
-    path := c.xpath(dg, base, []string{name})
-    obj, _ := c.versioning()
-    if _, err := fn(path, nil, obj); err != nil {
-        return Entry{}, err
-    }
-    ans := obj.Normalize()
+	path := c.xpath(dg, base, []string{name})
+	obj, _ := c.versioning()
+	if _, err := fn(path, nil, obj); err != nil {
+		return Entry{}, err
+	}
+	ans := obj.Normalize()
 
-    return ans, nil
+	return ans, nil
 }
 
 func (c *PanoNat) xpath(dg, base string, vals []string) []string {
-    if dg == "" {
-        dg = "shared"
-    }
-    if base == "" {
-        base = util.PreRulebase
-    }
+	if dg == "" {
+		dg = "shared"
+	}
+	if base == "" {
+		base = util.PreRulebase
+	}
 
-    if dg == "shared" {
-        return []string{
-            "config",
-            "shared",
-            base,
-            "nat",
-            "rules",
-            util.AsEntryXpath(vals),
-        }
-    }
+	if dg == "shared" {
+		return []string{
+			"config",
+			"shared",
+			base,
+			"nat",
+			"rules",
+			util.AsEntryXpath(vals),
+		}
+	}
 
-    return []string{
-        "config",
-        "devices",
-        util.AsEntryXpath([]string{"localhost.localdomain"}),
-        "device-group",
-        util.AsEntryXpath([]string{dg}),
-        base,
-        "nat",
-        "rules",
-        util.AsEntryXpath(vals),
-    }
+	return []string{
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"device-group",
+		util.AsEntryXpath([]string{dg}),
+		base,
+		"nat",
+		"rules",
+		util.AsEntryXpath(vals),
+	}
 }

--- a/poli/security/entry.go
+++ b/poli/security/entry.go
@@ -1,9 +1,9 @@
 package security
 
 import (
-    "encoding/xml"
+	"encoding/xml"
 
-    "github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/util"
 )
 
 // Entry is a normalized, version independent representation of a security
@@ -14,39 +14,39 @@ import (
 // nil if all vsys on that device should be included or if the device is a
 // virtual firewall (and thus only has vsys1).
 type Entry struct {
-    Name string
-    Type string
-    Description string
-    Tags []string // ordered
-    SourceZones []string // unordered
-    SourceAddresses []string // unordered
-    NegateSource bool
-    SourceUsers []string // unordered
-    HipProfiles []string // unordered
-    DestinationZones []string // unordered
-    DestinationAddresses []string // unordered
-    NegateDestination bool
-    Applications []string // unordered
-    Services []string // unordered
-    Categories []string // unordered
-    Action string
-    LogSetting string
-    LogStart bool
-    LogEnd bool
-    Disabled bool
-    Schedule string
-    IcmpUnreachable bool
-    DisableServerResponseInspection bool
-    Group string
-    Targets map[string] []string
-    NegateTarget bool
-    Virus string
-    Spyware string
-    Vulnerability string
-    UrlFiltering string
-    FileBlocking string
-    WildFireAnalysis string
-    DataFiltering string
+	Name                            string
+	Type                            string
+	Description                     string
+	Tags                            []string // ordered
+	SourceZones                     []string // unordered
+	SourceAddresses                 []string // unordered
+	NegateSource                    bool
+	SourceUsers                     []string // unordered
+	HipProfiles                     []string // unordered
+	DestinationZones                []string // unordered
+	DestinationAddresses            []string // unordered
+	NegateDestination               bool
+	Applications                    []string // unordered
+	Services                        []string // unordered
+	Categories                      []string // unordered
+	Action                          string
+	LogSetting                      string
+	LogStart                        bool
+	LogEnd                          bool
+	Disabled                        bool
+	Schedule                        string
+	IcmpUnreachable                 bool
+	DisableServerResponseInspection bool
+	Group                           string
+	Targets                         map[string][]string
+	NegateTarget                    bool
+	Virus                           string
+	Spyware                         string
+	Vulnerability                   string
+	UrlFiltering                    string
+	FileBlocking                    string
+	WildFireAnalysis                string
+	DataFiltering                   string
 }
 
 // Defaults sets params with uninitialized values to their GUI default setting.
@@ -65,254 +65,286 @@ type Entry struct {
 //      * Action: "allow"
 //      * LogEnd: true
 func (o *Entry) Defaults() {
-    if o.Type == "" {
-        o.Type = "universal"
-    }
+	if o.Type == "" {
+		o.Type = "universal"
+	}
 
-    if len(o.SourceZones) == 0 {
-        o.SourceZones = []string{"any"}
-    }
+	if len(o.SourceZones) == 0 {
+		o.SourceZones = []string{"any"}
+	}
 
-    if len(o.DestinationZones) == 0 {
-        o.DestinationZones = []string{"any"}
-    }
+	if len(o.DestinationZones) == 0 {
+		o.DestinationZones = []string{"any"}
+	}
 
-    if len(o.SourceAddresses) == 0 {
-        o.SourceAddresses = []string{"any"}
-    }
+	if len(o.SourceAddresses) == 0 {
+		o.SourceAddresses = []string{"any"}
+	}
 
-    if len(o.SourceUsers) == 0 {
-        o.SourceUsers = []string{"any"}
-    }
+	if len(o.SourceUsers) == 0 {
+		o.SourceUsers = []string{"any"}
+	}
 
-    if len(o.HipProfiles) == 0 {
-        o.HipProfiles = []string{"any"}
-    }
+	if len(o.HipProfiles) == 0 {
+		o.HipProfiles = []string{"any"}
+	}
 
-    if len(o.DestinationAddresses) == 0 {
-        o.DestinationAddresses = []string{"any"}
-    }
+	if len(o.DestinationAddresses) == 0 {
+		o.DestinationAddresses = []string{"any"}
+	}
 
-    if len(o.Applications) == 0 {
-        o.Applications = []string{"any"}
-    }
+	if len(o.Applications) == 0 {
+		o.Applications = []string{"any"}
+	}
 
-    if len(o.Services) == 0 {
-        o.Services = []string{"application-default"}
-    }
+	if len(o.Services) == 0 {
+		o.Services = []string{"application-default"}
+	}
 
-    if len(o.Categories) == 0 {
-        o.Categories = []string{"any"}
-    }
+	if len(o.Categories) == 0 {
+		o.Categories = []string{"any"}
+	}
 
-    if o.Action == "" {
-        o.Action = "allow"
-    }
+	if o.Action == "" {
+		o.Action = "allow"
+	}
 
-    if !o.LogEnd {
-        o.LogEnd = true
-    }
+	if !o.LogEnd {
+		o.LogEnd = true
+	}
 }
 
 // Copy copies the information from source Entry `s` to this object.  As the
 // Name field relates to the XPATH of this object, this field is not copied.
 func (o *Entry) Copy(s Entry) {
-    o.Type = s.Type
-    o.Description = s.Description
-    o.Tags = s.Tags
-    o.SourceZones = s.SourceZones
-    o.SourceAddresses = s.SourceAddresses
-    o.NegateSource = s.NegateSource
-    o.SourceUsers = s.SourceUsers
-    o.HipProfiles = s.HipProfiles
-    o.DestinationZones = s.DestinationZones
-    o.DestinationAddresses = s.DestinationAddresses
-    o.NegateDestination = s.NegateDestination
-    o.Applications = s.Applications
-    o.Services = s.Services
-    o.Categories = s.Categories
-    o.Action = s.Action
-    o.LogSetting = s.LogSetting
-    o.LogStart = s.LogStart
-    o.LogEnd = s.LogEnd
-    o.Disabled = s.Disabled
-    o.Schedule = s.Schedule
-    o.IcmpUnreachable = s.IcmpUnreachable
-    o.DisableServerResponseInspection = s.DisableServerResponseInspection
-    o.Group = s.Group
-    o.Targets = s.Targets
-    o.NegateTarget = s.NegateTarget
-    o.Virus = s.Virus
-    o.Spyware = s.Spyware
-    o.Vulnerability = s.Vulnerability
-    o.UrlFiltering = s.UrlFiltering
-    o.FileBlocking = s.FileBlocking
-    o.WildFireAnalysis = s.WildFireAnalysis
-    o.DataFiltering = s.DataFiltering
+	o.Type = s.Type
+	o.Description = s.Description
+	o.Tags = s.Tags
+	o.SourceZones = s.SourceZones
+	o.SourceAddresses = s.SourceAddresses
+	o.NegateSource = s.NegateSource
+	o.SourceUsers = s.SourceUsers
+	o.HipProfiles = s.HipProfiles
+	o.DestinationZones = s.DestinationZones
+	o.DestinationAddresses = s.DestinationAddresses
+	o.NegateDestination = s.NegateDestination
+	o.Applications = s.Applications
+	o.Services = s.Services
+	o.Categories = s.Categories
+	o.Action = s.Action
+	o.LogSetting = s.LogSetting
+	o.LogStart = s.LogStart
+	o.LogEnd = s.LogEnd
+	o.Disabled = s.Disabled
+	o.Schedule = s.Schedule
+	o.IcmpUnreachable = s.IcmpUnreachable
+	o.DisableServerResponseInspection = s.DisableServerResponseInspection
+	o.Group = s.Group
+	o.Targets = s.Targets
+	o.NegateTarget = s.NegateTarget
+	o.Virus = s.Virus
+	o.Spyware = s.Spyware
+	o.Vulnerability = s.Vulnerability
+	o.UrlFiltering = s.UrlFiltering
+	o.FileBlocking = s.FileBlocking
+	o.WildFireAnalysis = s.WildFireAnalysis
+	o.DataFiltering = s.DataFiltering
 }
 
 /** Structs / functions for normalization. **/
 
 type normalizer interface {
-    Normalize() Entry
+	Normalize() Entry
 }
 
 type container_v1 struct {
-    Answer entry_v1 `xml:"result>entry"`
+	Answer entry_v1 `xml:"result>entry"`
 }
 
 func (o *container_v1) Normalize() Entry {
-    ans := Entry{
-        Name: o.Answer.Name,
-        Type: o.Answer.Type,
-        Description: o.Answer.Description,
-        Tags: util.MemToStr(o.Answer.Tags),
-        SourceZones: util.MemToStr(o.Answer.SourceZones),
-        DestinationZones: util.MemToStr(o.Answer.DestinationZones),
-        SourceAddresses: util.MemToStr(o.Answer.SourceAddresses),
-        NegateSource: util.AsBool(o.Answer.NegateSource),
-        SourceUsers: util.MemToStr(o.Answer.SourceUsers),
-        HipProfiles: util.MemToStr(o.Answer.HipProfiles),
-        DestinationAddresses: util.MemToStr(o.Answer.DestinationAddresses),
-        NegateDestination: util.AsBool(o.Answer.NegateDestination),
-        Applications: util.MemToStr(o.Answer.Applications),
-        Services: util.MemToStr(o.Answer.Services),
-        Categories: util.MemToStr(o.Answer.Categories),
-        Action: o.Answer.Action,
-        LogSetting: o.Answer.LogSetting,
-        LogStart: util.AsBool(o.Answer.LogStart),
-        LogEnd: util.AsBool(o.Answer.LogEnd),
-        Disabled: util.AsBool(o.Answer.Disabled),
-        Schedule: o.Answer.Schedule,
-        IcmpUnreachable: util.AsBool(o.Answer.IcmpUnreachable),
-    }
-    if o.Answer.Options != nil {
-        ans.DisableServerResponseInspection = util.AsBool(o.Answer.Options.DisableServerResponseInspection)
-    }
-    if o.Answer.TargetInfo != nil {
-        ans.NegateTarget = util.AsBool(o.Answer.TargetInfo.NegateTarget)
-        ans.Targets = util.VsysEntToMap(o.Answer.TargetInfo.Targets)
-    }
-    if o.Answer.ProfileSettings != nil {
-        ans.Group = util.MemToOneStr(o.Answer.ProfileSettings.Group)
-        if o.Answer.ProfileSettings.Profiles != nil {
-            ans.Virus = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.Virus)
-            ans.Spyware = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.Spyware)
-            ans.Vulnerability = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.Vulnerability)
-            ans.UrlFiltering = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.UrlFiltering)
-            ans.FileBlocking = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.FileBlocking)
-            ans.WildFireAnalysis = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.WildFireAnalysis)
-            ans.DataFiltering = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.DataFiltering)
-        }
-    }
+	ans := Entry{
+		Name:                 o.Answer.Name,
+		Type:                 o.Answer.Type,
+		Description:          o.Answer.Description,
+		Tags:                 util.MemToStr(o.Answer.Tags),
+		SourceZones:          util.MemToStr(o.Answer.SourceZones),
+		DestinationZones:     util.MemToStr(o.Answer.DestinationZones),
+		SourceAddresses:      util.MemToStr(o.Answer.SourceAddresses),
+		NegateSource:         util.AsBool(o.Answer.NegateSource),
+		SourceUsers:          util.MemToStr(o.Answer.SourceUsers),
+		HipProfiles:          util.MemToStr(o.Answer.HipProfiles),
+		DestinationAddresses: util.MemToStr(o.Answer.DestinationAddresses),
+		NegateDestination:    util.AsBool(o.Answer.NegateDestination),
+		Applications:         util.MemToStr(o.Answer.Applications),
+		Services:             util.MemToStr(o.Answer.Services),
+		Categories:           util.MemToStr(o.Answer.Categories),
+		Action:               o.Answer.Action,
+		LogSetting:           o.Answer.LogSetting,
+		LogStart:             util.AsBool(o.Answer.LogStart),
+		LogEnd:               util.AsBool(o.Answer.LogEnd),
+		Disabled:             util.AsBool(o.Answer.Disabled),
+		Schedule:             o.Answer.Schedule,
+		IcmpUnreachable:      util.AsBool(o.Answer.IcmpUnreachable),
+	}
+	if o.Answer.Options != nil {
+		ans.DisableServerResponseInspection = util.AsBool(o.Answer.Options.DisableServerResponseInspection)
+	}
+	if o.Answer.TargetInfo != nil {
+		ans.NegateTarget = util.AsBool(o.Answer.TargetInfo.NegateTarget)
+		ans.Targets = util.VsysEntToMap(o.Answer.TargetInfo.Targets)
+	}
+	if o.Answer.ProfileSettings != nil {
+		ans.Group = util.MemToOneStr(o.Answer.ProfileSettings.Group)
+		if o.Answer.ProfileSettings.Profiles != nil {
+			ans.Virus = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.Virus)
+			ans.Spyware = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.Spyware)
+			ans.Vulnerability = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.Vulnerability)
+			ans.UrlFiltering = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.UrlFiltering)
+			ans.FileBlocking = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.FileBlocking)
+			ans.WildFireAnalysis = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.WildFireAnalysis)
+			ans.DataFiltering = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.DataFiltering)
+		}
+	}
 
-    return ans
+	return ans
 }
 
 type entry_v1 struct {
-    XMLName xml.Name `xml:"entry"`
-    Name string `xml:"name,attr"`
-    Type string `xml:"rule-type"`
-    Description string `xml:"description"`
-    Tags *util.MemberType `xml:"tag"`
-    SourceZones *util.MemberType `xml:"from"`
-    DestinationZones *util.MemberType `xml:"to"`
-    SourceAddresses *util.MemberType `xml:"source"`
-    NegateSource string `xml:"negate-source"`
-    SourceUsers *util.MemberType `xml:"source-user"`
-    HipProfiles *util.MemberType `xml:"hip-profiles"`
-    DestinationAddresses *util.MemberType `xml:"destination"`
-    NegateDestination string `xml:"negate-destination"`
-    Applications *util.MemberType `xml:"application"`
-    Services *util.MemberType `xml:"service"`
-    Categories *util.MemberType `xml:"category"`
-    Action string `xml:"action"`
-    LogSetting string `xml:"log-setting,omitempty"`
-    LogStart string `xml:"log-start"`
-    LogEnd string `xml:"log-end"`
-    Disabled string `xml:"disabled"`
-    Schedule string `xml:"schedule,omitempty"`
-    IcmpUnreachable string `xml:"icmp-unreachable"`
-    Options *secOptions `xml:"option"`
-    TargetInfo *targetInfo `xml:"target"`
-    ProfileSettings *profileSettings `xml:"profile-setting"`
+	XMLName              xml.Name         `xml:"entry"`
+	Name                 string           `xml:"name,attr"`
+	Type                 string           `xml:"rule-type"`
+	Description          string           `xml:"description"`
+	Tags                 *util.MemberType `xml:"tag"`
+	SourceZones          *util.MemberType `xml:"from"`
+	DestinationZones     *util.MemberType `xml:"to"`
+	SourceAddresses      *util.MemberType `xml:"source"`
+	NegateSource         string           `xml:"negate-source"`
+	SourceUsers          *util.MemberType `xml:"source-user"`
+	HipProfiles          *util.MemberType `xml:"hip-profiles"`
+	DestinationAddresses *util.MemberType `xml:"destination"`
+	NegateDestination    string           `xml:"negate-destination"`
+	Applications         *util.MemberType `xml:"application"`
+	Services             *util.MemberType `xml:"service"`
+	Categories           *util.MemberType `xml:"category"`
+	Action               string           `xml:"action"`
+	LogSetting           string           `xml:"log-setting,omitempty"`
+	LogStart             string           `xml:"log-start"`
+	LogEnd               string           `xml:"log-end"`
+	Disabled             string           `xml:"disabled"`
+	Schedule             string           `xml:"schedule,omitempty"`
+	IcmpUnreachable      string           `xml:"icmp-unreachable"`
+	Options              *secOptions      `xml:"option"`
+	TargetInfo           *targetInfo      `xml:"target"`
+	ProfileSettings      *profileSettings `xml:"profile-setting"`
 }
 
 type secOptions struct {
-    DisableServerResponseInspection string `xml:"disable-server-response-inspection,omitempty"`
+	DisableServerResponseInspection string `xml:"disable-server-response-inspection,omitempty"`
 }
 
 type targetInfo struct {
-    Targets *util.VsysEntryType `xml:"devices"`
-    NegateTarget string `xml:"negate,omitempty"`
+	Targets      *util.VsysEntryType `xml:"devices"`
+	NegateTarget string              `xml:"negate,omitempty"`
 }
 
 type profileSettings struct {
-    Group *util.MemberType `xml:"group"`
-    Profiles *profileSettingsProfile `xml:"profiles"`
+	Group    *util.MemberType        `xml:"group"`
+	Profiles *profileSettingsProfile `xml:"profiles"`
 }
 
 type profileSettingsProfile struct {
-    Virus *util.MemberType `xml:"virus"`
-    Spyware *util.MemberType `xml:"spyware"`
-    Vulnerability *util.MemberType `xml:"vulnerability"`
-    UrlFiltering *util.MemberType `xml:"url-filtering"`
-    FileBlocking *util.MemberType `xml:"file-blocking"`
-    WildFireAnalysis *util.MemberType `xml:"wildfire-analysis"`
-    DataFiltering *util.MemberType `xml:"data-filtering"`
+	Virus            *util.MemberType `xml:"virus"`
+	Spyware          *util.MemberType `xml:"spyware"`
+	Vulnerability    *util.MemberType `xml:"vulnerability"`
+	UrlFiltering     *util.MemberType `xml:"url-filtering"`
+	FileBlocking     *util.MemberType `xml:"file-blocking"`
+	WildFireAnalysis *util.MemberType `xml:"wildfire-analysis"`
+	DataFiltering    *util.MemberType `xml:"data-filtering"`
 }
 
 func specify_v1(e Entry) interface{} {
-    ans := entry_v1{
-        Name: e.Name,
-        Type: e.Type,
-        Description: e.Description,
-        Tags: util.StrToMem(e.Tags),
-        SourceZones: util.StrToMem(e.SourceZones),
-        DestinationZones: util.StrToMem(e.DestinationZones),
-        SourceAddresses: util.StrToMem(e.SourceAddresses),
-        NegateSource: util.YesNo(e.NegateSource),
-        SourceUsers: util.StrToMem(e.SourceUsers),
-        HipProfiles: util.StrToMem(e.HipProfiles),
-        DestinationAddresses: util.StrToMem(e.DestinationAddresses),
-        NegateDestination: util.YesNo(e.NegateDestination),
-        Applications: util.StrToMem(e.Applications),
-        Services: util.StrToMem(e.Services),
-        Categories: util.StrToMem(e.Categories),
-        Action: e.Action,
-        LogSetting: e.LogSetting,
-        LogStart: util.YesNo(e.LogStart),
-        LogEnd: util.YesNo(e.LogEnd),
-        Disabled: util.YesNo(e.Disabled),
-        Schedule: e.Schedule,
-        IcmpUnreachable: util.YesNo(e.IcmpUnreachable),
-        Options: &secOptions{util.YesNo(e.DisableServerResponseInspection)},
-    }
-    if e.Targets != nil || e.NegateTarget {
-        nfo := &targetInfo{
-            Targets: util.MapToVsysEnt(e.Targets),
-            NegateTarget: util.YesNo(e.NegateTarget),
-        }
-        ans.TargetInfo = nfo
-    }
-    gs := e.Virus != "" || e.Spyware != "" || e.Vulnerability != "" || e.UrlFiltering != "" || e.FileBlocking != "" || e.WildFireAnalysis != "" || e.DataFiltering != ""
-    if e.Group != "" || gs {
-        ps := &profileSettings{
-            Group: util.OneStrToMem(e.Group),
-        }
-        if gs {
-            ps.Profiles = &profileSettingsProfile{
-                util.OneStrToMem(e.Virus),
-                util.OneStrToMem(e.Spyware),
-                util.OneStrToMem(e.Vulnerability),
-                util.OneStrToMem(e.UrlFiltering),
-                util.OneStrToMem(e.FileBlocking),
-                util.OneStrToMem(e.WildFireAnalysis),
-                util.OneStrToMem(e.DataFiltering),
-            }
-        }
-        ans.ProfileSettings = ps
-    }
+	ans := entry_v1{
+		Name:                 e.Name,
+		Type:                 e.Type,
+		Description:          e.Description,
+		Tags:                 util.StrToMem(e.Tags),
+		SourceZones:          util.StrToMem(e.SourceZones),
+		DestinationZones:     util.StrToMem(e.DestinationZones),
+		SourceAddresses:      util.StrToMem(e.SourceAddresses),
+		NegateSource:         util.YesNo(e.NegateSource),
+		SourceUsers:          util.StrToMem(e.SourceUsers),
+		HipProfiles:          util.StrToMem(e.HipProfiles),
+		DestinationAddresses: util.StrToMem(e.DestinationAddresses),
+		NegateDestination:    util.YesNo(e.NegateDestination),
+		Applications:         util.StrToMem(e.Applications),
+		Services:             util.StrToMem(e.Services),
+		Categories:           util.StrToMem(e.Categories),
+		Action:               e.Action,
+		LogSetting:           e.LogSetting,
+		LogStart:             util.YesNo(e.LogStart),
+		LogEnd:               util.YesNo(e.LogEnd),
+		Disabled:             util.YesNo(e.Disabled),
+		Schedule:             e.Schedule,
+		IcmpUnreachable:      util.YesNo(e.IcmpUnreachable),
+		Options:              &secOptions{util.YesNo(e.DisableServerResponseInspection)},
+	}
+	if e.Targets != nil || e.NegateTarget {
+		nfo := &targetInfo{
+			Targets:      util.MapToVsysEnt(e.Targets),
+			NegateTarget: util.YesNo(e.NegateTarget),
+		}
+		ans.TargetInfo = nfo
+	}
+	gs := e.Virus != "" || e.Spyware != "" || e.Vulnerability != "" || e.UrlFiltering != "" || e.FileBlocking != "" || e.WildFireAnalysis != "" || e.DataFiltering != ""
+	if e.Group != "" || gs {
+		ps := &profileSettings{
+			Group: util.OneStrToMem(e.Group),
+		}
+		if gs {
+			ps.Profiles = &profileSettingsProfile{
+				util.OneStrToMem(e.Virus),
+				util.OneStrToMem(e.Spyware),
+				util.OneStrToMem(e.Vulnerability),
+				util.OneStrToMem(e.UrlFiltering),
+				util.OneStrToMem(e.FileBlocking),
+				util.OneStrToMem(e.WildFireAnalysis),
+				util.OneStrToMem(e.DataFiltering),
+			}
+		}
+		ans.ProfileSettings = ps
+	}
 
-    return ans
+	return ans
+}
+
+//EntryContainerMulti container for full list of security policies
+type EntryContainerMulti struct {
+	Entries []Entry `xml:"response>result>rulebase>security>rules>entry"`
+}
+
+//UnmarshalXML parses raw result for the rulebase xml tree
+func (e *EntryContainerMulti) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for {
+		token, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch childToken := token.(type) {
+		case xml.StartElement:
+			switch childToken.Name.Local {
+			case "entry":
+				entry := entry_v1{}
+				err = d.DecodeElement(&entry, &childToken)
+				if err != nil {
+					return err
+				}
+				containerized := container_v1{entry}
+				e.Entries = append(e.Entries, containerized.Normalize())
+			}
+		case xml.EndElement:
+			if childToken == start.End() {
+				return nil
+			}
+		}
+	}
 }

--- a/poli/security/fw.go
+++ b/poli/security/fw.go
@@ -1,104 +1,128 @@
 package security
 
 import (
-    "fmt"
-    "encoding/xml"
-    "strings"
+	"encoding/xml"
+	"fmt"
+	"strings"
 
-    "github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/util"
 )
 
 // FwSecurity is the client.Policies.Security namespace.
 type FwSecurity struct {
-    con util.XapiClient
+	con util.XapiClient
 }
 
 // Initialize is invoed by client.Initialize().
 func (c *FwSecurity) Initialize(con util.XapiClient) {
-    c.con = con
+	c.con = con
 }
 
 // GetList performs GET to retrieve a list of security policies.
 func (c *FwSecurity) GetList(vsys string) ([]string, error) {
-    c.con.LogQuery("(get) list of security policies")
-    path := c.xpath(vsys, nil)
-    return c.con.EntryListUsing(c.con.Get, path[:len(path) - 1])
+	c.con.LogQuery("(get) list of security policies")
+	path := c.xpath(vsys, nil)
+	return c.con.EntryListUsing(c.con.Get, path[:len(path)-1])
+}
+
+// GetFullList performs GET to retreive a list of security policies
+func (c *FwSecurity) GetFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(get) list of service objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // ShowList performs SHOW to retrieve a list of security policies.
 func (c *FwSecurity) ShowList(vsys string) ([]string, error) {
-    c.con.LogQuery("(show) list of security policies")
-    path := c.xpath(vsys, nil)
-    return c.con.EntryListUsing(c.con.Show, path[:len(path) - 1])
+	c.con.LogQuery("(show) list of security policies")
+	path := c.xpath(vsys, nil)
+	return c.con.EntryListUsing(c.con.Show, path[:len(path)-1])
+}
+
+// ShowFullList performs SHOW to retreive a list of security policies
+func (c *FwSecurity) ShowFullList(vsys string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(show) list of service objects")
+	path := c.xpath(vsys, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // Get performs GET to retrieve information for the given security policy.
 func (c *FwSecurity) Get(vsys, name string) (Entry, error) {
-    c.con.LogQuery("(get) security policy %q", name)
-    return c.details(c.con.Get, vsys, name)
+	c.con.LogQuery("(get) security policy %q", name)
+	return c.details(c.con.Get, vsys, name)
 }
 
 // Get performs SHOW to retrieve information for the given security policy.
 func (c *FwSecurity) Show(vsys, name string) (Entry, error) {
-    c.con.LogQuery("(show) security policy %q", name)
-    return c.details(c.con.Show, vsys, name)
+	c.con.LogQuery("(show) security policy %q", name)
+	return c.details(c.con.Show, vsys, name)
 }
 
 // Set performs SET to create / update one or more security policies.
 func (c *FwSecurity) Set(vsys string, e ...Entry) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    } else {
-        // Make sure rule names are unique.
-        m := make(map[string] int)
-        for i := range e {
-            m[e[i].Name] = m[e[i].Name] + 1
-            if m[e[i].Name] > 1 {
-                return fmt.Errorf("Security rule is defined multiple times: %s", e[i].Name)
-            }
-        }
-    }
+	if len(e) == 0 {
+		return nil
+	} else {
+		// Make sure rule names are unique.
+		m := make(map[string]int)
+		for i := range e {
+			m[e[i].Name] = m[e[i].Name] + 1
+			if m[e[i].Name] > 1 {
+				return fmt.Errorf("Security rule is defined multiple times: %s", e[i].Name)
+			}
+		}
+	}
 
-    _, fn := c.versioning()
-    names := make([]string, len(e))
+	_, fn := c.versioning()
+	names := make([]string, len(e))
 
-    // Build up the struct with the given security policy configs.
-    d := util.BulkElement{XMLName: xml.Name{Local: "rules"}}
-    for i := range e {
-        d.Data = append(d.Data, fn(e[i]))
-        names[i] = e[i].Name
-    }
-    c.con.LogAction("(set) security policies: %v", names)
+	// Build up the struct with the given security policy configs.
+	d := util.BulkElement{XMLName: xml.Name{Local: "rules"}}
+	for i := range e {
+		d.Data = append(d.Data, fn(e[i]))
+		names[i] = e[i].Name
+	}
+	c.con.LogAction("(set) security policies: %v", names)
 
-    // Set xpath.
-    path := c.xpath(vsys, names)
-    if len(e) == 1 {
-        path = path[:len(path) - 1]
-    } else {
-        path = path[:len(path) - 2]
-    }
+	// Set xpath.
+	path := c.xpath(vsys, names)
+	if len(e) == 1 {
+		path = path[:len(path)-1]
+	} else {
+		path = path[:len(path)-2]
+	}
 
-    // Create the security policies.
-    _, err = c.con.Set(path, d.Config(), nil, nil)
+	// Create the security policies.
+	_, err = c.con.Set(path, d.Config(), nil, nil)
 
-    // On error: find the rule that's causing the error if multiple rules
-    // were given.
-    if err != nil && strings.Contains(err.Error(), "rules is invalid") {
-        for i := 0; i < len(e); i++ {
-            if e2 := c.Set(vsys, e[i]); e2 != nil {
-                return fmt.Errorf("Error with rule %d: %s", i + 1, e2)
-            } else {
-                _ = c.Delete(vsys, e[i])
-            }
-        }
+	// On error: find the rule that's causing the error if multiple rules
+	// were given.
+	if err != nil && strings.Contains(err.Error(), "rules is invalid") {
+		for i := 0; i < len(e); i++ {
+			if e2 := c.Set(vsys, e[i]); e2 != nil {
+				return fmt.Errorf("Error with rule %d: %s", i+1, e2)
+			} else {
+				_ = c.Delete(vsys, e[i])
+			}
+		}
 
-        // Couldn't find it, just return the original error.
-        return err
-    }
+		// Couldn't find it, just return the original error.
+		return err
+	}
 
-    return err
+	return err
 }
 
 // VerifiableSet behaves like Set(), except policies with LogEnd as true
@@ -110,41 +134,41 @@ func (c *FwSecurity) Set(vsys string, e ...Entry) error {
 // get around this by setting the value to a non-standard value, then back
 // again, in which case it will properly show up in the returned XML.
 func (c *FwSecurity) VerifiableSet(vsys string, e ...Entry) error {
-    c.con.LogAction("(set) performing verifiable set")
-    again := make([]Entry, 0, len(e))
+	c.con.LogAction("(set) performing verifiable set")
+	again := make([]Entry, 0, len(e))
 
-    for i := range e {
-        if e[i].LogEnd {
-            again = append(again, e[i])
-            e[i].LogEnd = false
-        }
-    }
+	for i := range e {
+		if e[i].LogEnd {
+			again = append(again, e[i])
+			e[i].LogEnd = false
+		}
+	}
 
-    if err := c.Set(vsys, e...); err != nil {
-        return err
-    }
+	if err := c.Set(vsys, e...); err != nil {
+		return err
+	}
 
-    if len(again) == 0 {
-        return nil
-    }
+	if len(again) == 0 {
+		return nil
+	}
 
-    return c.Set(vsys, again...)
+	return c.Set(vsys, again...)
 }
 
 // Edit performs EDIT to create / update a security policy.
 func (c *FwSecurity) Edit(vsys string, e Entry) error {
-    var err error
+	var err error
 
-    _, fn := c.versioning()
+	_, fn := c.versioning()
 
-    c.con.LogAction("(edit) security policy %q", e.Name)
+	c.con.LogAction("(edit) security policy %q", e.Name)
 
-    // Set xpath.
-    path := c.xpath(vsys, []string{e.Name})
+	// Set xpath.
+	path := c.xpath(vsys, []string{e.Name})
 
-    // Edit the security policy.
-    _, err = c.con.Edit(path, fn(e), nil, nil)
-    return err
+	// Edit the security policy.
+	_, err = c.con.Edit(path, fn(e), nil, nil)
+	return err
 }
 
 // VerifiableEdit behaves like Edit(), except policies with LogEnd as true
@@ -156,71 +180,71 @@ func (c *FwSecurity) Edit(vsys string, e Entry) error {
 // get around this by setting the value to a non-standard value, then back
 // again, in which case it will properly show up in the returned XML.
 func (c *FwSecurity) VerifiableEdit(vsys string, e ...Entry) error {
-    var err error
+	var err error
 
-    c.con.LogAction("(edit) performing verifiable edit")
-    again := make([]Entry, 0, len(e))
+	c.con.LogAction("(edit) performing verifiable edit")
+	again := make([]Entry, 0, len(e))
 
-    for i := range e {
-        if e[i].LogEnd {
-            again = append(again, e[i])
-            e[i].LogEnd = false
-        }
-        if err = c.Edit(vsys, e[i]); err != nil {
-            return err
-        }
-    }
+	for i := range e {
+		if e[i].LogEnd {
+			again = append(again, e[i])
+			e[i].LogEnd = false
+		}
+		if err = c.Edit(vsys, e[i]); err != nil {
+			return err
+		}
+	}
 
-    if len(again) == 0 {
-        return nil
-    }
+	if len(again) == 0 {
+		return nil
+	}
 
-    // It's ok to do a SET following an EDIT because we are guaranteed
-    // to not have stray or conflicting config, so use SET since it
-    // supports bulk operations.
-    return c.Set(vsys, again...)
+	// It's ok to do a SET following an EDIT because we are guaranteed
+	// to not have stray or conflicting config, so use SET since it
+	// supports bulk operations.
+	return c.Set(vsys, again...)
 }
 
 // Delete removes the given security policies.
 //
 // Security policies can be either a string or an Entry object.
 func (c *FwSecurity) Delete(vsys string, e ...interface{}) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    names := make([]string, len(e))
-    for i := range e {
-        switch v := e[i].(type) {
-        case string:
-            names[i] = v
-        case Entry:
-            names[i] = v.Name
-        default:
-            return fmt.Errorf("Unsupported type to delete: %s", v)
-        }
-    }
-    c.con.LogAction("(delete) security policies: %v", names)
+	names := make([]string, len(e))
+	for i := range e {
+		switch v := e[i].(type) {
+		case string:
+			names[i] = v
+		case Entry:
+			names[i] = v.Name
+		default:
+			return fmt.Errorf("Unsupported type to delete: %s", v)
+		}
+	}
+	c.con.LogAction("(delete) security policies: %v", names)
 
-    path := c.xpath(vsys, names)
-    _, err = c.con.Delete(path, nil, nil)
-    return err
+	path := c.xpath(vsys, names)
+	_, err = c.con.Delete(path, nil, nil)
+	return err
 }
 
 // DeleteAll removes all security policies from the specified vsys.
 func (c *FwSecurity) DeleteAll(vsys string) error {
-    c.con.LogAction("(delete) all security policies")
-    list, err := c.GetList(vsys)
-    if err != nil || len(list) == 0 {
-        return err
-    }
-    li := make([]interface{}, len(list))
-    for i := range list {
-        li[i] = list[i]
-    }
-    return c.Delete(vsys, li...)
+	c.con.LogAction("(delete) all security policies")
+	list, err := c.GetList(vsys)
+	if err != nil || len(list) == 0 {
+		return err
+	}
+	li := make([]interface{}, len(list))
+	for i := range list {
+		li[i] = list[i]
+	}
+	return c.Delete(vsys, li...)
 }
 
 // MoveGroup moves a logical group of security policies somewhere in relation
@@ -234,136 +258,136 @@ func (c *FwSecurity) DeleteAll(vsys string) error {
 // anywhere, but all other policies will still be moved to be grouped with the
 // first one.
 func (c *FwSecurity) MoveGroup(vsys string, movement int, rule string, e ...Entry) error {
-    var err error
+	var err error
 
-    fIdx := -1
-    oIdx := -1
+	fIdx := -1
+	oIdx := -1
 
-    c.con.LogAction("(move) security policy group")
-    if len(e) < 1 {
-        return fmt.Errorf("Requires at least one security policy")
-    } else if rule == e[0].Name {
-        return fmt.Errorf("Can't position %q in relation to itself", rule)
-    } else if movement != util.MoveSkip && movement != util.MoveBefore && movement != util.MoveDirectlyBefore && movement != util.MoveAfter && movement != util.MoveDirectlyAfter && movement != util.MoveTop && movement != util.MoveBottom {
-        return fmt.Errorf("Invalid position specified: %d", movement)
-    } else if (movement == util.MoveBefore || movement == util.MoveDirectlyBefore || movement == util.MoveAfter || movement == util.MoveDirectlyAfter) && rule == "" {
-        return fmt.Errorf("Specify 'rule' in order to perform relative group positioning")
-    }
-    path := c.xpath(vsys, []string{e[0].Name})
+	c.con.LogAction("(move) security policy group")
+	if len(e) < 1 {
+		return fmt.Errorf("Requires at least one security policy")
+	} else if rule == e[0].Name {
+		return fmt.Errorf("Can't position %q in relation to itself", rule)
+	} else if movement != util.MoveSkip && movement != util.MoveBefore && movement != util.MoveDirectlyBefore && movement != util.MoveAfter && movement != util.MoveDirectlyAfter && movement != util.MoveTop && movement != util.MoveBottom {
+		return fmt.Errorf("Invalid position specified: %d", movement)
+	} else if (movement == util.MoveBefore || movement == util.MoveDirectlyBefore || movement == util.MoveAfter || movement == util.MoveDirectlyAfter) && rule == "" {
+		return fmt.Errorf("Specify 'rule' in order to perform relative group positioning")
+	}
+	path := c.xpath(vsys, []string{e[0].Name})
 
-    if movement != util.MoveSkip {
-        // Get the list of current security policies.
-        curList, err := c.GetList(vsys)
-        if err != nil {
-            return err
-        } else if len(curList) == 0 {
-            return fmt.Errorf("No policies found")
-        }
+	if movement != util.MoveSkip {
+		// Get the list of current security policies.
+		curList, err := c.GetList(vsys)
+		if err != nil {
+			return err
+		} else if len(curList) == 0 {
+			return fmt.Errorf("No policies found")
+		}
 
-        switch movement {
-        case util.MoveTop:
-            _, em := c.con.Move(path, "top", "", nil, nil)
-            if em != nil {
-                if em.Error() != "already at the top" {
-                    err = em
-                }
-            }
-        case util.MoveBottom:
-            _, em := c.con.Move(path, "bottom", "", nil, nil)
-            if em != nil {
-                if em.Error() != "already at the bottom" {
-                    err = em
-                }
-            }
-        default:
-            // Find the indexes of the first security policy and the ref policy.
-            for i, v := range curList {
-                if v == e[0].Name {
-                    fIdx = i
-                } else if v == rule {
-                    oIdx = i
-                }
-                if fIdx != -1 && oIdx != -1 {
-                    break
-                }
-            }
+		switch movement {
+		case util.MoveTop:
+			_, em := c.con.Move(path, "top", "", nil, nil)
+			if em != nil {
+				if em.Error() != "already at the top" {
+					err = em
+				}
+			}
+		case util.MoveBottom:
+			_, em := c.con.Move(path, "bottom", "", nil, nil)
+			if em != nil {
+				if em.Error() != "already at the bottom" {
+					err = em
+				}
+			}
+		default:
+			// Find the indexes of the first security policy and the ref policy.
+			for i, v := range curList {
+				if v == e[0].Name {
+					fIdx = i
+				} else if v == rule {
+					oIdx = i
+				}
+				if fIdx != -1 && oIdx != -1 {
+					break
+				}
+			}
 
-            // Sanity check:  both rules should be present.
-            if fIdx == -1 {
-                return fmt.Errorf("First security policy in group %q does not exist", e[0].Name)
-            } else if oIdx == -1 {
-                return fmt.Errorf("Reference security policy %q does not exist", rule)
-            }
+			// Sanity check:  both rules should be present.
+			if fIdx == -1 {
+				return fmt.Errorf("First security policy in group %q does not exist", e[0].Name)
+			} else if oIdx == -1 {
+				return fmt.Errorf("Reference security policy %q does not exist", rule)
+			}
 
-            // Perform the move of the first security policy, if needed.
-            if (movement == util.MoveBefore && fIdx > oIdx) || (movement == util.MoveDirectlyBefore && fIdx + 1 != oIdx) {
-                _, err = c.con.Move(path, "before", rule, nil, nil)
-            } else if (movement == util.MoveAfter && fIdx < oIdx) || (movement == util.MoveDirectlyAfter && fIdx != oIdx + 1) {
-                _, err = c.con.Move(path, "after", rule, nil, nil)
-            }
-        }
+			// Perform the move of the first security policy, if needed.
+			if (movement == util.MoveBefore && fIdx > oIdx) || (movement == util.MoveDirectlyBefore && fIdx+1 != oIdx) {
+				_, err = c.con.Move(path, "before", rule, nil, nil)
+			} else if (movement == util.MoveAfter && fIdx < oIdx) || (movement == util.MoveDirectlyAfter && fIdx != oIdx+1) {
+				_, err = c.con.Move(path, "after", rule, nil, nil)
+			}
+		}
 
-        // If we moved something, make sure it worked.
-        if err != nil {
-            return err
-        }
-    }
+		// If we moved something, make sure it worked.
+		if err != nil {
+			return err
+		}
+	}
 
-    // Now move all other rules under the first.
-    li := len(path) - 1
-    for i := 1; i < len(e); i++ {
-        path[li] = util.AsEntryXpath([]string{e[i].Name})
-        _, err = c.con.Move(path, "after", e[i - 1].Name, nil, nil)
-        if err != nil {
-            return err
-        }
-    }
+	// Now move all other rules under the first.
+	li := len(path) - 1
+	for i := 1; i < len(e); i++ {
+		path[li] = util.AsEntryXpath([]string{e[i].Name})
+		_, err = c.con.Move(path, "after", e[i-1].Name, nil, nil)
+		if err != nil {
+			return err
+		}
+	}
 
-    return nil
+	return nil
 }
 
 /** Internal functions for the FwSecurity struct **/
 
-func (c *FwSecurity) versioning() (normalizer, func(Entry) (interface{})) {
-    return &container_v1{}, specify_v1
+func (c *FwSecurity) versioning() (normalizer, func(Entry) interface{}) {
+	return &container_v1{}, specify_v1
 }
 
 func (c *FwSecurity) details(fn util.Retriever, vsys, name string) (Entry, error) {
-    path := c.xpath(vsys, []string{name})
-    obj, _ := c.versioning()
-    if _, err := fn(path, nil, obj); err != nil {
-        return Entry{}, err
-    }
-    ans := obj.Normalize()
+	path := c.xpath(vsys, []string{name})
+	obj, _ := c.versioning()
+	if _, err := fn(path, nil, obj); err != nil {
+		return Entry{}, err
+	}
+	ans := obj.Normalize()
 
-    return ans, nil
+	return ans, nil
 }
 
 func (c *FwSecurity) xpath(vsys string, vals []string) []string {
-    if vsys == "" {
-        vsys = "vsys1"
-    }
+	if vsys == "" {
+		vsys = "vsys1"
+	}
 
-    if vsys == "shared" {
-        return []string{
-            "config",
-            "shared",
-            "rulebase",
-            "security",
-            "rules",
-            util.AsEntryXpath(vals),
-        }
-    }
+	if vsys == "shared" {
+		return []string{
+			"config",
+			"shared",
+			"rulebase",
+			"security",
+			"rules",
+			util.AsEntryXpath(vals),
+		}
+	}
 
-    return []string{
-        "config",
-        "devices",
-        util.AsEntryXpath([]string{"localhost.localdomain"}),
-        "vsys",
-        util.AsEntryXpath([]string{vsys}),
-        "rulebase",
-        "security",
-        "rules",
-        util.AsEntryXpath(vals),
-    }
+	return []string{
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"vsys",
+		util.AsEntryXpath([]string{vsys}),
+		"rulebase",
+		"security",
+		"rules",
+		util.AsEntryXpath(vals),
+	}
 }

--- a/poli/security/pano.go
+++ b/poli/security/pano.go
@@ -1,104 +1,128 @@
 package security
 
 import (
-    "fmt"
-    "encoding/xml"
-    "strings"
+	"encoding/xml"
+	"fmt"
+	"strings"
 
-    "github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/util"
 )
 
 // PanoSecurity is the client.Policies.Security namespace.
 type PanoSecurity struct {
-    con util.XapiClient
+	con util.XapiClient
 }
 
 // Initialize is invoed by client.Initialize().
 func (c *PanoSecurity) Initialize(con util.XapiClient) {
-    c.con = con
+	c.con = con
 }
 
 // GetList performs GET to retrieve a list of security policies.
 func (c *PanoSecurity) GetList(dg, base string) ([]string, error) {
-    c.con.LogQuery("(get) list of security policies")
-    path := c.xpath(dg, base, nil)
-    return c.con.EntryListUsing(c.con.Get, path[:len(path) - 1])
+	c.con.LogQuery("(get) list of security policies")
+	path := c.xpath(dg, base, nil)
+	return c.con.EntryListUsing(c.con.Get, path[:len(path)-1])
+}
+
+// GetFullList performs GET to retreive a list of security policies
+func (c *PanoSecurity) GetFullList(dg, base string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(get) list of service objects")
+	path := c.xpath(dg, base, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // ShowList performs SHOW to retrieve a list of security policies.
 func (c *PanoSecurity) ShowList(dg, base string) ([]string, error) {
-    c.con.LogQuery("(show) list of security policies")
-    path := c.xpath(dg, base, nil)
-    return c.con.EntryListUsing(c.con.Show, path[:len(path) - 1])
+	c.con.LogQuery("(show) list of security policies")
+	path := c.xpath(dg, base, nil)
+	return c.con.EntryListUsing(c.con.Show, path[:len(path)-1])
+}
+
+// ShowFullList performs SHOW to retreive a list of security policies
+func (c *PanoSecurity) ShowFullList(dg, base string) (EntryContainerMulti, error) {
+	c.con.LogQuery("(show) list of service objects")
+	path := c.xpath(dg, base, nil)
+	ans := EntryContainerMulti{}
+	err := c.con.EntryObjectsUsing(c.con.Get, path[:len(path)-1], &ans)
+	if err != nil {
+		return EntryContainerMulti{}, err
+	}
+	return ans, nil
 }
 
 // Get performs GET to retrieve information for the given security policy.
 func (c *PanoSecurity) Get(dg, base, name string) (Entry, error) {
-    c.con.LogQuery("(get) security policy %q", name)
-    return c.details(c.con.Get, dg, base, name)
+	c.con.LogQuery("(get) security policy %q", name)
+	return c.details(c.con.Get, dg, base, name)
 }
 
 // Get performs SHOW to retrieve information for the given security policy.
 func (c *PanoSecurity) Show(dg, base, name string) (Entry, error) {
-    c.con.LogQuery("(show) security policy %q", name)
-    return c.details(c.con.Show, dg, base, name)
+	c.con.LogQuery("(show) security policy %q", name)
+	return c.details(c.con.Show, dg, base, name)
 }
 
 // Set performs SET to create / update one or more security policies.
 func (c *PanoSecurity) Set(dg, base string, e ...Entry) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    } else {
-        // Make sure rule names are unique.
-        m := make(map[string] int)
-        for i := range e {
-            m[e[i].Name] = m[e[i].Name] + 1
-            if m[e[i].Name] > 1 {
-                return fmt.Errorf("Security rule is defined multiple times: %s", e[i].Name)
-            }
-        }
-    }
+	if len(e) == 0 {
+		return nil
+	} else {
+		// Make sure rule names are unique.
+		m := make(map[string]int)
+		for i := range e {
+			m[e[i].Name] = m[e[i].Name] + 1
+			if m[e[i].Name] > 1 {
+				return fmt.Errorf("Security rule is defined multiple times: %s", e[i].Name)
+			}
+		}
+	}
 
-    _, fn := c.versioning()
-    names := make([]string, len(e))
+	_, fn := c.versioning()
+	names := make([]string, len(e))
 
-    // Build up the struct with the given security policy configs.
-    d := util.BulkElement{XMLName: xml.Name{Local: "rules"}}
-    for i := range e {
-        d.Data = append(d.Data, fn(e[i]))
-        names[i] = e[i].Name
-    }
-    c.con.LogAction("(set) security policies: %v", names)
+	// Build up the struct with the given security policy configs.
+	d := util.BulkElement{XMLName: xml.Name{Local: "rules"}}
+	for i := range e {
+		d.Data = append(d.Data, fn(e[i]))
+		names[i] = e[i].Name
+	}
+	c.con.LogAction("(set) security policies: %v", names)
 
-    // Set xpath.
-    path := c.xpath(dg, base, names)
-    if len(e) == 1 {
-        path = path[:len(path) - 1]
-    } else {
-        path = path[:len(path) - 2]
-    }
+	// Set xpath.
+	path := c.xpath(dg, base, names)
+	if len(e) == 1 {
+		path = path[:len(path)-1]
+	} else {
+		path = path[:len(path)-2]
+	}
 
-    // Create the security policies.
-    _, err = c.con.Set(path, d.Config(), nil, nil)
+	// Create the security policies.
+	_, err = c.con.Set(path, d.Config(), nil, nil)
 
-    // On error: find the rule that's causing the error if multiple rules
-    // were given.
-    if err != nil && strings.Contains(err.Error(), "rules is invalid") {
-        for i := 0; i < len(e); i++ {
-            if e2 := c.Set(dg, base, e[i]); e2 != nil {
-                return fmt.Errorf("Error with rule %d: %s", i + 1, e2)
-            } else {
-                _ = c.Delete(dg, base, e[i])
-            }
-        }
+	// On error: find the rule that's causing the error if multiple rules
+	// were given.
+	if err != nil && strings.Contains(err.Error(), "rules is invalid") {
+		for i := 0; i < len(e); i++ {
+			if e2 := c.Set(dg, base, e[i]); e2 != nil {
+				return fmt.Errorf("Error with rule %d: %s", i+1, e2)
+			} else {
+				_ = c.Delete(dg, base, e[i])
+			}
+		}
 
-        // Couldn't find it, just return the original error.
-        return err
-    }
+		// Couldn't find it, just return the original error.
+		return err
+	}
 
-    return err
+	return err
 }
 
 // VerifiableSet behaves like Set(), except policies with LogEnd as true
@@ -110,41 +134,41 @@ func (c *PanoSecurity) Set(dg, base string, e ...Entry) error {
 // get around this by setting the value to a non-standard value, then back
 // again, in which case it will properly show up in the returned XML.
 func (c *PanoSecurity) VerifiableSet(dg, base string, e ...Entry) error {
-    c.con.LogAction("(set) performing verifiable set")
-    again := make([]Entry, 0, len(e))
+	c.con.LogAction("(set) performing verifiable set")
+	again := make([]Entry, 0, len(e))
 
-    for i := range e {
-        if e[i].LogEnd {
-            again = append(again, e[i])
-            e[i].LogEnd = false
-        }
-    }
+	for i := range e {
+		if e[i].LogEnd {
+			again = append(again, e[i])
+			e[i].LogEnd = false
+		}
+	}
 
-    if err := c.Set(dg, base, e...); err != nil {
-        return err
-    }
+	if err := c.Set(dg, base, e...); err != nil {
+		return err
+	}
 
-    if len(again) == 0 {
-        return nil
-    }
+	if len(again) == 0 {
+		return nil
+	}
 
-    return c.Set(dg, base, again...)
+	return c.Set(dg, base, again...)
 }
 
 // Edit performs EDIT to create / update a security policy.
 func (c *PanoSecurity) Edit(dg, base string, e Entry) error {
-    var err error
+	var err error
 
-    _, fn := c.versioning()
+	_, fn := c.versioning()
 
-    c.con.LogAction("(edit) security policy %q", e.Name)
+	c.con.LogAction("(edit) security policy %q", e.Name)
 
-    // Set xpath.
-    path := c.xpath(dg, base, []string{e.Name})
+	// Set xpath.
+	path := c.xpath(dg, base, []string{e.Name})
 
-    // Edit the security policy.
-    _, err = c.con.Edit(path, fn(e), nil, nil)
-    return err
+	// Edit the security policy.
+	_, err = c.con.Edit(path, fn(e), nil, nil)
+	return err
 }
 
 // VerifiableEdit behaves like Edit(), except policies with LogEnd as true
@@ -156,71 +180,71 @@ func (c *PanoSecurity) Edit(dg, base string, e Entry) error {
 // get around this by setting the value to a non-standard value, then back
 // again, in which case it will properly show up in the returned XML.
 func (c *PanoSecurity) VerifiableEdit(dg, base string, e ...Entry) error {
-    var err error
+	var err error
 
-    c.con.LogAction("(edit) performing verifiable edit")
-    again := make([]Entry, 0, len(e))
+	c.con.LogAction("(edit) performing verifiable edit")
+	again := make([]Entry, 0, len(e))
 
-    for i := range e {
-        if e[i].LogEnd {
-            again = append(again, e[i])
-            e[i].LogEnd = false
-        }
-        if err = c.Edit(dg, base, e[i]); err != nil {
-            return err
-        }
-    }
+	for i := range e {
+		if e[i].LogEnd {
+			again = append(again, e[i])
+			e[i].LogEnd = false
+		}
+		if err = c.Edit(dg, base, e[i]); err != nil {
+			return err
+		}
+	}
 
-    if len(again) == 0 {
-        return nil
-    }
+	if len(again) == 0 {
+		return nil
+	}
 
-    // It's ok to do a SET following an EDIT because we are guaranteed
-    // to not have stray or conflicting config, so use SET since it
-    // supports bulk operations.
-    return c.Set(dg, base, again...)
+	// It's ok to do a SET following an EDIT because we are guaranteed
+	// to not have stray or conflicting config, so use SET since it
+	// supports bulk operations.
+	return c.Set(dg, base, again...)
 }
 
 // Delete removes the given security policies.
 //
 // Security policies can be either a string or an Entry object.
 func (c *PanoSecurity) Delete(dg, base string, e ...interface{}) error {
-    var err error
+	var err error
 
-    if len(e) == 0 {
-        return nil
-    }
+	if len(e) == 0 {
+		return nil
+	}
 
-    names := make([]string, len(e))
-    for i := range e {
-        switch v := e[i].(type) {
-        case string:
-            names[i] = v
-        case Entry:
-            names[i] = v.Name
-        default:
-            return fmt.Errorf("Unsupported type to delete: %s", v)
-        }
-    }
-    c.con.LogAction("(delete) security policies: %v", names)
+	names := make([]string, len(e))
+	for i := range e {
+		switch v := e[i].(type) {
+		case string:
+			names[i] = v
+		case Entry:
+			names[i] = v.Name
+		default:
+			return fmt.Errorf("Unsupported type to delete: %s", v)
+		}
+	}
+	c.con.LogAction("(delete) security policies: %v", names)
 
-    path := c.xpath(dg, base, names)
-    _, err = c.con.Delete(path, nil, nil)
-    return err
+	path := c.xpath(dg, base, names)
+	_, err = c.con.Delete(path, nil, nil)
+	return err
 }
 
 // DeleteAll removes all security policies from the specified dg / rulebase.
 func (c *PanoSecurity) DeleteAll(dg, base string) error {
-    c.con.LogAction("(delete) all security policies")
-    list, err := c.GetList(dg, base)
-    if err != nil || len(list) == 0 {
-        return err
-    }
-    li := make([]interface{}, len(list))
-    for i := range list {
-        li[i] = list[i]
-    }
-    return c.Delete(dg, base, li...)
+	c.con.LogAction("(delete) all security policies")
+	list, err := c.GetList(dg, base)
+	if err != nil || len(list) == 0 {
+		return err
+	}
+	li := make([]interface{}, len(list))
+	for i := range list {
+		li[i] = list[i]
+	}
+	return c.Delete(dg, base, li...)
 }
 
 // MoveGroup moves a logical group of security policies somewhere in relation
@@ -234,139 +258,139 @@ func (c *PanoSecurity) DeleteAll(dg, base string) error {
 // anywhere, but all other policies will still be moved to be grouped with the
 // first one.
 func (c *PanoSecurity) MoveGroup(dg, base string, movement int, rule string, e ...Entry) error {
-    var err error
+	var err error
 
-    fIdx := -1
-    oIdx := -1
+	fIdx := -1
+	oIdx := -1
 
-    c.con.LogAction("(move) security policy group")
-    if len(e) < 1 {
-        return fmt.Errorf("Requires at least one security policy")
-    } else if rule == e[0].Name {
-        return fmt.Errorf("Can't position %q in relation to itself", rule)
-    } else if movement != util.MoveSkip && movement != util.MoveBefore && movement != util.MoveDirectlyBefore && movement != util.MoveAfter && movement != util.MoveDirectlyAfter && movement != util.MoveTop && movement != util.MoveBottom {
-        return fmt.Errorf("Invalid position specified: %d", movement)
-    } else if (movement == util.MoveBefore || movement == util.MoveDirectlyBefore || movement == util.MoveAfter || movement == util.MoveDirectlyAfter) && rule == "" {
-        return fmt.Errorf("Specify 'rule' in order to perform relative group positioning")
-    }
-    path := c.xpath(dg, base, []string{e[0].Name})
+	c.con.LogAction("(move) security policy group")
+	if len(e) < 1 {
+		return fmt.Errorf("Requires at least one security policy")
+	} else if rule == e[0].Name {
+		return fmt.Errorf("Can't position %q in relation to itself", rule)
+	} else if movement != util.MoveSkip && movement != util.MoveBefore && movement != util.MoveDirectlyBefore && movement != util.MoveAfter && movement != util.MoveDirectlyAfter && movement != util.MoveTop && movement != util.MoveBottom {
+		return fmt.Errorf("Invalid position specified: %d", movement)
+	} else if (movement == util.MoveBefore || movement == util.MoveDirectlyBefore || movement == util.MoveAfter || movement == util.MoveDirectlyAfter) && rule == "" {
+		return fmt.Errorf("Specify 'rule' in order to perform relative group positioning")
+	}
+	path := c.xpath(dg, base, []string{e[0].Name})
 
-    if movement != util.MoveSkip {
-        // Get the list of current security policies.
-        curList, err := c.GetList(dg, base)
-        if err != nil {
-            return err
-        } else if len(curList) == 0 {
-            return fmt.Errorf("No policies found")
-        }
+	if movement != util.MoveSkip {
+		// Get the list of current security policies.
+		curList, err := c.GetList(dg, base)
+		if err != nil {
+			return err
+		} else if len(curList) == 0 {
+			return fmt.Errorf("No policies found")
+		}
 
-        switch movement {
-        case util.MoveTop:
-            _, em := c.con.Move(path, "top", "", nil, nil)
-            if em != nil {
-                if em.Error() != "already at the top" {
-                    err = em
-                }
-            }
-        case util.MoveBottom:
-            _, em := c.con.Move(path, "bottom", "", nil, nil)
-            if em != nil {
-                if em.Error() != "already at the bottom" {
-                    err = em
-                }
-            }
-        default:
-            // Find the indexes of the first security policy and the ref policy.
-            for i, v := range curList {
-                if v == e[0].Name {
-                    fIdx = i
-                } else if v == rule {
-                    oIdx = i
-                }
-                if fIdx != -1 && oIdx != -1 {
-                    break
-                }
-            }
+		switch movement {
+		case util.MoveTop:
+			_, em := c.con.Move(path, "top", "", nil, nil)
+			if em != nil {
+				if em.Error() != "already at the top" {
+					err = em
+				}
+			}
+		case util.MoveBottom:
+			_, em := c.con.Move(path, "bottom", "", nil, nil)
+			if em != nil {
+				if em.Error() != "already at the bottom" {
+					err = em
+				}
+			}
+		default:
+			// Find the indexes of the first security policy and the ref policy.
+			for i, v := range curList {
+				if v == e[0].Name {
+					fIdx = i
+				} else if v == rule {
+					oIdx = i
+				}
+				if fIdx != -1 && oIdx != -1 {
+					break
+				}
+			}
 
-            // Sanity check:  both rules should be present.
-            if fIdx == -1 {
-                return fmt.Errorf("First security policy in group %q does not exist", e[0].Name)
-            } else if oIdx == -1 {
-                return fmt.Errorf("Reference security policy %q does not exist", rule)
-            }
+			// Sanity check:  both rules should be present.
+			if fIdx == -1 {
+				return fmt.Errorf("First security policy in group %q does not exist", e[0].Name)
+			} else if oIdx == -1 {
+				return fmt.Errorf("Reference security policy %q does not exist", rule)
+			}
 
-            // Perform the move of the first security policy, if needed.
-            if (movement == util.MoveBefore && fIdx > oIdx) || (movement == util.MoveDirectlyBefore && fIdx + 1 != oIdx) {
-                _, err = c.con.Move(path, "before", rule, nil, nil)
-            } else if (movement == util.MoveAfter && fIdx < oIdx) || (movement == util.MoveDirectlyAfter && fIdx != oIdx + 1) {
-                _, err = c.con.Move(path, "after", rule, nil, nil)
-            }
-        }
+			// Perform the move of the first security policy, if needed.
+			if (movement == util.MoveBefore && fIdx > oIdx) || (movement == util.MoveDirectlyBefore && fIdx+1 != oIdx) {
+				_, err = c.con.Move(path, "before", rule, nil, nil)
+			} else if (movement == util.MoveAfter && fIdx < oIdx) || (movement == util.MoveDirectlyAfter && fIdx != oIdx+1) {
+				_, err = c.con.Move(path, "after", rule, nil, nil)
+			}
+		}
 
-        // If we moved something, make sure it worked.
-        if err != nil {
-            return err
-        }
-    }
+		// If we moved something, make sure it worked.
+		if err != nil {
+			return err
+		}
+	}
 
-    // Now move all other rules under the first.
-    li := len(path) - 1
-    for i := 1; i < len(e); i++ {
-        path[li] = util.AsEntryXpath([]string{e[i].Name})
-        _, err = c.con.Move(path, "after", e[i - 1].Name, nil, nil)
-        if err != nil {
-            return err
-        }
-    }
+	// Now move all other rules under the first.
+	li := len(path) - 1
+	for i := 1; i < len(e); i++ {
+		path[li] = util.AsEntryXpath([]string{e[i].Name})
+		_, err = c.con.Move(path, "after", e[i-1].Name, nil, nil)
+		if err != nil {
+			return err
+		}
+	}
 
-    return nil
+	return nil
 }
 
 /** Internal functions for the PanoSecurity struct **/
 
-func (c *PanoSecurity) versioning() (normalizer, func(Entry) (interface{})) {
-    return &container_v1{}, specify_v1
+func (c *PanoSecurity) versioning() (normalizer, func(Entry) interface{}) {
+	return &container_v1{}, specify_v1
 }
 
 func (c *PanoSecurity) details(fn util.Retriever, dg, base, name string) (Entry, error) {
-    path := c.xpath(dg, base, []string{name})
-    obj, _ := c.versioning()
-    if _, err := fn(path, nil, obj); err != nil {
-        return Entry{}, err
-    }
-    ans := obj.Normalize()
+	path := c.xpath(dg, base, []string{name})
+	obj, _ := c.versioning()
+	if _, err := fn(path, nil, obj); err != nil {
+		return Entry{}, err
+	}
+	ans := obj.Normalize()
 
-    return ans, nil
+	return ans, nil
 }
 
 func (c *PanoSecurity) xpath(dg, base string, vals []string) []string {
-    if dg == "" {
-        dg = "shared"
-    }
-    if base == "" {
-        base = util.PreRulebase
-    }
+	if dg == "" {
+		dg = "shared"
+	}
+	if base == "" {
+		base = util.PreRulebase
+	}
 
-    if dg == "shared" {
-        return []string{
-            "config",
-            "shared",
-            base,
-            "security",
-            "rules",
-            util.AsEntryXpath(vals),
-        }
-    }
+	if dg == "shared" {
+		return []string{
+			"config",
+			"shared",
+			base,
+			"security",
+			"rules",
+			util.AsEntryXpath(vals),
+		}
+	}
 
-    return []string{
-        "config",
-        "devices",
-        util.AsEntryXpath([]string{"localhost.localdomain"}),
-        "device-group",
-        util.AsEntryXpath([]string{dg}),
-        base,
-        "security",
-        "rules",
-        util.AsEntryXpath(vals),
-    }
+	return []string{
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"device-group",
+		util.AsEntryXpath([]string{dg}),
+		base,
+		"security",
+		"rules",
+		util.AsEntryXpath(vals),
+	}
 }

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -1,204 +1,210 @@
 package testdata
 
 import (
-    "fmt"
-    "encoding/xml"
+	"encoding/xml"
+	"fmt"
 
-    "github.com/PaloAltoNetworks/pango/version"
-    "github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
 )
 
-
 type Response struct {
-    Raw []byte
-    Error error
+	Raw   []byte
+	Error error
 }
 
 type MockClient struct {
-    // Variables for response.
-    Resp []Response
-    Called int
-    Version version.Number
-    Plugin []map[string] string
-    PasswordHash string
-    UnimportError error
+	// Variables for response.
+	Resp          []Response
+	Called        int
+	Version       version.Number
+	Plugin        []map[string]string
+	PasswordHash  string
+	UnimportError error
 
-    // Variables saved from the mock client's invocation.
-    Function string
-    Imports []string
-    Unimports []string
-    Path string
-    Elm string
-    Template string
-    TemplateStack string
-    Vsys string
-    Extras interface{}
+	// Variables saved from the mock client's invocation.
+	Function      string
+	Imports       []string
+	Unimports     []string
+	Path          string
+	Elm           string
+	Template      string
+	TemplateStack string
+	Vsys          string
+	Extras        interface{}
 }
 
-func (c *MockClient) String() string { return "mock" }
-func (c *MockClient) Versioning() version.Number { return c.Version }
-func (c *MockClient) Plugins() []map[string] string { return c.Plugin }
-func (c *MockClient) LogAction(f string, a...interface{}) {}
-func (c *MockClient) LogQuery(f string, a...interface{}) {}
-func (c *MockClient) LogOp(f string, a...interface{}) {}
-func (c *MockClient) LogUid(f string, a...interface{}) {}
-func (c *MockClient) Commit(d string, e []string, f, g, h, i bool) (uint, error) { return 0, nil }
+func (c *MockClient) String() string                                              { return "mock" }
+func (c *MockClient) Versioning() version.Number                                  { return c.Version }
+func (c *MockClient) Plugins() []map[string]string                                { return c.Plugin }
+func (c *MockClient) LogAction(f string, a ...interface{})                        {}
+func (c *MockClient) LogQuery(f string, a ...interface{})                         {}
+func (c *MockClient) LogOp(f string, a ...interface{})                            {}
+func (c *MockClient) LogUid(f string, a ...interface{})                           {}
+func (c *MockClient) Commit(d string, e []string, f, g, h, i bool) (uint, error)  { return 0, nil }
 func (c *MockClient) PositionFirstEntity(d int, e, f string, g, h []string) error { return nil }
 
 func (c *MockClient) Op(req interface{}, vsys string, extras interface{}, ans interface{}) ([]byte, error) {
-    c.Function = "op"
-    if err := c.SetElm(req); err != nil {
-        return nil, err
-    }
-    c.Vsys = vsys
-    c.Extras = extras
+	c.Function = "op"
+	if err := c.SetElm(req); err != nil {
+		return nil, err
+	}
+	c.Vsys = vsys
+	c.Extras = extras
 
-    return c.finalize(ans)
+	return c.finalize(ans)
 }
 
 func (c *MockClient) Show(path interface{}, extras interface{}, ans interface{}) ([]byte, error) {
-    c.Function = "show"
-    c.Path = util.AsXpath(path)
-    c.Extras = extras
+	c.Function = "show"
+	c.Path = util.AsXpath(path)
+	c.Extras = extras
 
-    return c.finalize(ans)
+	return c.finalize(ans)
 }
 
 func (c *MockClient) Get(path interface{}, extras interface{}, ans interface{}) ([]byte, error) {
-    c.Function = "get"
-    c.Path = util.AsXpath(path)
-    c.Extras = extras
+	c.Function = "get"
+	c.Path = util.AsXpath(path)
+	c.Extras = extras
 
-    return c.finalize(ans)
+	return c.finalize(ans)
 }
 
 func (c *MockClient) Delete(path interface{}, extras interface{}, ans interface{}) ([]byte, error) {
-    c.Function = "delete"
-    c.Path = util.AsXpath(path)
-    c.Extras = extras
+	c.Function = "delete"
+	c.Path = util.AsXpath(path)
+	c.Extras = extras
 
-    return c.finalize(ans)
+	return c.finalize(ans)
 }
 
 func (c *MockClient) Set(path, elm, extras, ans interface{}) ([]byte, error) {
-    c.Function = "set"
-    if err := c.SetElm(elm); err != nil {
-        return nil, err
-    }
-    c.Path = util.AsXpath(path)
-    c.Extras = extras
+	c.Function = "set"
+	if err := c.SetElm(elm); err != nil {
+		return nil, err
+	}
+	c.Path = util.AsXpath(path)
+	c.Extras = extras
 
-    return c.finalize(ans)
+	return c.finalize(ans)
 }
 
 func (c *MockClient) Edit(path, elm, extras, ans interface{}) ([]byte, error) {
-    c.Function = "edit"
-    if err := c.SetElm(elm); err != nil {
-        return nil, err
-    }
-    c.Path = util.AsXpath(path)
-    c.Extras = extras
+	c.Function = "edit"
+	if err := c.SetElm(elm); err != nil {
+		return nil, err
+	}
+	c.Path = util.AsXpath(path)
+	c.Extras = extras
 
-    return c.finalize(ans)
+	return c.finalize(ans)
 }
 
-func (c *MockClient) Move(path interface{}, where, dst string, extras, ans interface{}) ([]byte, error) { return nil, nil }
+func (c *MockClient) Move(path interface{}, where, dst string, extras, ans interface{}) ([]byte, error) {
+	return nil, nil
+}
 
 func (c *MockClient) Uid(cmd interface{}, vsys string, extras, resp interface{}) ([]byte, error) {
-    c.Function = "uid"
-    if err := c.SetElm(cmd); err != nil {
-        return nil, err
-    }
-    c.Vsys = vsys
-    c.Extras = extras
+	c.Function = "uid"
+	if err := c.SetElm(cmd); err != nil {
+		return nil, err
+	}
+	c.Vsys = vsys
+	c.Extras = extras
 
-    return c.finalize(resp)
+	return c.finalize(resp)
 }
 
 func (c *MockClient) EntryListUsing(fn util.Retriever, path []string) ([]string, error) {
-    c.Path = util.AsXpath(path)
-    return nil, nil
+	c.Path = util.AsXpath(path)
+	return nil, nil
+}
+
+func (c *MockClient) EntryObjectsUsing(fn util.Retriever, path []string, target interface{}) error {
+	c.Path = util.AsXpath(path)
+	return nil
 }
 
 func (c *MockClient) MemberListUsing(fn util.Retriever, path []string) ([]string, error) {
-    c.Path = util.AsXpath(path)
-    return nil, nil
+	c.Path = util.AsXpath(path)
+	return nil, nil
 }
 
 func (c *MockClient) RequestPasswordHash(a string) (string, error) { return c.PasswordHash, nil }
 
 func (c *MockClient) finalize(resp interface{}) ([]byte, error) {
-    ans := c.Resp[c.Called % len(c.Resp)]
-    c.Called++
+	ans := c.Resp[c.Called%len(c.Resp)]
+	c.Called++
 
-    if resp == nil {
-        return ans.Raw, ans.Error
-    }
+	if resp == nil {
+		return ans.Raw, ans.Error
+	}
 
-    if err := xml.Unmarshal(ans.Raw, resp); err != nil {
-        return nil, err
-    }
+	if err := xml.Unmarshal(ans.Raw, resp); err != nil {
+		return nil, err
+	}
 
-    return ans.Raw, ans.Error
+	return ans.Raw, ans.Error
 }
 
 func (c *MockClient) SetElm(e interface{}) error {
-    if e == nil {
-        return nil
-    }
+	if e == nil {
+		return nil
+	}
 
-    rb, err := xml.Marshal(e)
-    if err != nil {
-        return err
-    }
+	rb, err := xml.Marshal(e)
+	if err != nil {
+		return err
+	}
 
-    c.Elm = string(rb)
-    return nil
+	c.Elm = string(rb)
+	return nil
 }
 
 func (c *MockClient) VsysImport(ns, tmpl, ts, vsys string, names []string) error {
-    c.Template = tmpl
-    c.TemplateStack = ts
-    c.Vsys = vsys
-    c.Imports = names
+	c.Template = tmpl
+	c.TemplateStack = ts
+	c.Vsys = vsys
+	c.Imports = names
 
-    return nil
+	return nil
 }
 
 func (c *MockClient) VsysUnimport(ns, tmpl, ts string, names []string) error {
-    c.Template = tmpl
-    c.TemplateStack = ts
-    c.Unimports = names
+	c.Template = tmpl
+	c.TemplateStack = ts
+	c.Unimports = names
 
-    return c.UnimportError
+	return c.UnimportError
 }
 
 func (c *MockClient) WaitForJob(a uint, resp interface{}) error {
-    _, err := c.finalize(resp)
-    return err
+	_, err := c.finalize(resp)
+	return err
 }
 
 func (c *MockClient) AddResp(val string) {
-    c.Resp = append(c.Resp, Response{
-        []byte(fmt.Sprintf("<response><result>%s</result></response>", val)), nil,
-    })
+	c.Resp = append(c.Resp, Response{
+		[]byte(fmt.Sprintf("<response><result>%s</result></response>", val)), nil,
+	})
 }
 
 func (c *MockClient) Reset() {
-    c.Function = ""
-    c.Imports = []string{}
-    c.Unimports = []string{}
-    c.Path = ""
-    c.Elm = ""
-    c.Template = ""
-    c.TemplateStack = ""
-    c.Vsys = ""
-    c.Extras = nil
+	c.Function = ""
+	c.Imports = []string{}
+	c.Unimports = []string{}
+	c.Path = ""
+	c.Elm = ""
+	c.Template = ""
+	c.TemplateStack = ""
+	c.Vsys = ""
+	c.Extras = nil
 }
 
 const (
-    ApiKeyXml = "<response><result><key>secret</key></result></response>"
-    LicenseXml = `<response><result><licenses>
+	ApiKeyXml  = "<response><result><key>secret</key></result></response>"
+	LicenseXml = `<response><result><licenses>
     <entry>
         <feature>Feature 1</feature>
         <description>License for feature</description>
@@ -216,7 +222,7 @@ const (
         <expired>N/A</expired>
     </entry>
     </licenses></result></response>`
-    UserIdXml = `<response><result>
+	UserIdXml = `<response><result>
     <entry ip="10.1.1.1">
         <tag>
             <member>one</member>

--- a/util/util.go
+++ b/util/util.go
@@ -2,15 +2,14 @@
 // the pango package.
 package util
 
-
 import (
-    "bytes"
-    "encoding/xml"
-    "fmt"
-    "regexp"
-    "strings"
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"regexp"
+	"strings"
 
-    "github.com/PaloAltoNetworks/pango/version"
+	"github.com/PaloAltoNetworks/pango/version"
 )
 
 // Retriever is a type that is intended to act as a stand-in for using
@@ -19,208 +18,209 @@ type Retriever func(interface{}, interface{}, interface{}) ([]byte, error)
 
 // Rulebase constants for various policies.
 const (
-    Rulebase = "rulebase"
-    PreRulebase = "pre-rulebase"
-    PostRulebase = "post-rulebase"
+	Rulebase     = "rulebase"
+	PreRulebase  = "pre-rulebase"
+	PostRulebase = "post-rulebase"
 )
 
 // Valid values to use for VsysImport() or VsysUnimport().
 const (
-    InterfaceImport = "interface"
-    VirtualRouterImport = "virtual-router"
-    VirtualWireImport = "virtual-wire"
-    VlanImport = "vlan"
+	InterfaceImport     = "interface"
+	VirtualRouterImport = "virtual-router"
+	VirtualWireImport   = "virtual-wire"
+	VlanImport          = "vlan"
 )
 
 // XapiClient is the interface that describes an pango.Client.
 type XapiClient interface {
-    String() string
-    Versioning() version.Number
-    LogAction(string, ...interface{})
-    LogQuery(string, ...interface{})
-    LogOp(string, ...interface{})
-    LogUid(string, ...interface{})
-    Op(interface{}, string, interface{}, interface{}) ([]byte, error)
-    Show(interface{}, interface{}, interface{}) ([]byte, error)
-    Get(interface{}, interface{}, interface{}) ([]byte, error)
-    Delete(interface{}, interface{}, interface{}) ([]byte, error)
-    Set(interface{}, interface{}, interface{}, interface{}) ([]byte, error)
-    Edit(interface{}, interface{}, interface{}, interface{}) ([]byte, error)
-    Move(interface{}, string, string, interface{}, interface{}) ([]byte, error)
-    Uid(interface{}, string, interface{}, interface{}) ([]byte, error)
-    EntryListUsing(Retriever, []string) ([]string, error)
-    MemberListUsing(Retriever, []string) ([]string, error)
-    RequestPasswordHash(string) (string, error)
-    VsysImport(string, string, string, string, []string) error
-    VsysUnimport(string, string, string, []string) error
-    WaitForJob(uint, interface{}) error
-    Commit(string, []string, bool, bool, bool, bool) (uint, error)
-    PositionFirstEntity(int, string, string, []string, []string) error
+	String() string
+	Versioning() version.Number
+	LogAction(string, ...interface{})
+	LogQuery(string, ...interface{})
+	LogOp(string, ...interface{})
+	LogUid(string, ...interface{})
+	Op(interface{}, string, interface{}, interface{}) ([]byte, error)
+	Show(interface{}, interface{}, interface{}) ([]byte, error)
+	Get(interface{}, interface{}, interface{}) ([]byte, error)
+	Delete(interface{}, interface{}, interface{}) ([]byte, error)
+	Set(interface{}, interface{}, interface{}, interface{}) ([]byte, error)
+	Edit(interface{}, interface{}, interface{}, interface{}) ([]byte, error)
+	Move(interface{}, string, string, interface{}, interface{}) ([]byte, error)
+	Uid(interface{}, string, interface{}, interface{}) ([]byte, error)
+	EntryListUsing(Retriever, []string) ([]string, error)
+	EntryObjectsUsing(Retriever, []string, interface{}) error
+	MemberListUsing(Retriever, []string) ([]string, error)
+	RequestPasswordHash(string) (string, error)
+	VsysImport(string, string, string, string, []string) error
+	VsysUnimport(string, string, string, []string) error
+	WaitForJob(uint, interface{}) error
+	Commit(string, []string, bool, bool, bool, bool) (uint, error)
+	PositionFirstEntity(int, string, string, []string, []string) error
 }
 
 // BulkElement is a generic bulk container for bulk operations.
 type BulkElement struct {
-    XMLName xml.Name
-    Data []interface{}
+	XMLName xml.Name
+	Data    []interface{}
 }
 
 // Config returns an interface to be Marshaled.
 func (o BulkElement) Config() interface{} {
-    if len(o.Data) == 1 {
-        return o.Data[0]
-    }
-    return o
+	if len(o.Data) == 1 {
+		return o.Data[0]
+	}
+	return o
 }
 
 // MemberType defines a member config node used for sending and receiving XML
 // from PAN-OS.
 type MemberType struct {
-    Members []Member `xml:"member"`
+	Members []Member `xml:"member"`
 }
 
 // Member defines a member config node used for sending and receiving XML
 // from PANOS.
 type Member struct {
-    XMLName xml.Name `xml:"member"`
-    Value string `xml:",chardata"`
+	XMLName xml.Name `xml:"member"`
+	Value   string   `xml:",chardata"`
 }
 
 // MemToStr normalizes a MemberType pointer into a list of strings.
 func MemToStr(e *MemberType) []string {
-    if e == nil {
-        return nil
-    }
+	if e == nil {
+		return nil
+	}
 
-    ans := make([]string, len(e.Members))
-    for i := range e.Members {
-        ans[i] = e.Members[i].Value
-    }
+	ans := make([]string, len(e.Members))
+	for i := range e.Members {
+		ans[i] = e.Members[i].Value
+	}
 
-    return ans
+	return ans
 }
 
 // StrToMem converts a list of strings into a MemberType pointer.
 func StrToMem(e []string) *MemberType {
-    if e == nil {
-        return nil
-    }
+	if e == nil {
+		return nil
+	}
 
-    ans := make([]Member, len(e))
-    for i := range e {
-        ans[i] = Member{Value: e[i]}
-    }
+	ans := make([]Member, len(e))
+	for i := range e {
+		ans[i] = Member{Value: e[i]}
+	}
 
-    return &MemberType{ans}
+	return &MemberType{ans}
 }
 
 // MemToOneStr normalizes a MemberType pointer for a max_items=1 XML node
 // into a string.
 func MemToOneStr(e *MemberType) string {
-    if e == nil || len(e.Members) == 0 {
-        return ""
-    }
+	if e == nil || len(e.Members) == 0 {
+		return ""
+	}
 
-    return e.Members[0].Value
+	return e.Members[0].Value
 }
 
 // OneStrToMem converts a string into a MemberType pointer for a max_items=1
 // XML node.
 func OneStrToMem(e string) *MemberType {
-    if e == "" {
-        return nil
-    }
+	if e == "" {
+		return nil
+	}
 
-    return &MemberType{[]Member{
-        {Value: e},
-    }}
+	return &MemberType{[]Member{
+		{Value: e},
+	}}
 }
 
 // EntryType defines an entry config node used for sending and receiving XML
 // from PAN-OS.
 type EntryType struct {
-    Entries []Entry `xml:"entry"`
+	Entries []Entry `xml:"entry"`
 }
 
 // Entry is a standalone entry struct.
 type Entry struct {
-    XMLName xml.Name `xml:"entry"`
-    Value string `xml:"name,attr"`
+	XMLName xml.Name `xml:"entry"`
+	Value   string   `xml:"name,attr"`
 }
 
 // EntToStr normalizes an EntryType pointer into a list of strings.
 func EntToStr(e *EntryType) []string {
-    if e == nil {
-        return nil
-    }
+	if e == nil {
+		return nil
+	}
 
-    ans := make([]string, len(e.Entries))
-    for i := range e.Entries {
-        ans[i] = e.Entries[i].Value
-    }
+	ans := make([]string, len(e.Entries))
+	for i := range e.Entries {
+		ans[i] = e.Entries[i].Value
+	}
 
-    return ans
+	return ans
 }
 
 // StrToEnt converts a list of strings into an EntryType pointer.
 func StrToEnt(e []string) *EntryType {
-    if e == nil {
-        return nil
-    }
+	if e == nil {
+		return nil
+	}
 
-    ans := make([]Entry, len(e))
-    for i := range e {
-        ans[i] = Entry{Value: e[i]}
-    }
+	ans := make([]Entry, len(e))
+	for i := range e {
+		ans[i] = Entry{Value: e[i]}
+	}
 
-    return &EntryType{ans}
+	return &EntryType{ans}
 }
 
 // EntToOneStr normalizes an EntryType pointer for a max_items=1 XML node
 // into a string.
 func EntToOneStr(e *EntryType) string {
-    if e == nil || len(e.Entries) == 0 {
-        return ""
-    }
+	if e == nil || len(e.Entries) == 0 {
+		return ""
+	}
 
-    return e.Entries[0].Value
+	return e.Entries[0].Value
 }
 
 // OneStrToEnt converts a string into an EntryType pointer for a max_items=1
 // XML node.
 func OneStrToEnt(e string) *EntryType {
-    if e == "" {
-        return nil
-    }
+	if e == "" {
+		return nil
+	}
 
-    return &EntryType{[]Entry{
-        {Value: e},
-    }}
+	return &EntryType{[]Entry{
+		{Value: e},
+	}}
 }
 
 // VsysEntryType defines an entry config node with vsys entries underneath.
 type VsysEntryType struct {
-    Entries []VsysEntry `xml:"entry"`
+	Entries []VsysEntry `xml:"entry"`
 }
 
 // VsysEntry defines the "vsys" xpath node under a VsysEntryType config node.
 type VsysEntry struct {
-    XMLName xml.Name `xml:"entry"`
-    Serial string `xml:"name,attr"`
-    Vsys *EntryType `xml:"vsys"`
+	XMLName xml.Name   `xml:"entry"`
+	Serial  string     `xml:"name,attr"`
+	Vsys    *EntryType `xml:"vsys"`
 }
 
 // VsysEntToMap normalizes a VsysEntryType pointer into a map.
-func VsysEntToMap(ve *VsysEntryType) (map[string] []string) {
-    if ve == nil {
-        return nil
-    }
+func VsysEntToMap(ve *VsysEntryType) map[string][]string {
+	if ve == nil {
+		return nil
+	}
 
-    ans := make(map[string] []string)
-    for i := range ve.Entries {
-        ans[ve.Entries[i].Serial] = EntToStr(ve.Entries[i].Vsys)
-    }
+	ans := make(map[string][]string)
+	for i := range ve.Entries {
+		ans[ve.Entries[i].Serial] = EntToStr(ve.Entries[i].Vsys)
+	}
 
-    return ans
+	return ans
 }
 
 // MapToVsysEnt converts a map into a VsysEntryType pointer.
@@ -229,221 +229,221 @@ func VsysEntToMap(ve *VsysEntryType) (map[string] []string) {
 // various policies.  Maps are unordered, but FWICT Panorama doesn't seem to
 // order anything anyways when doing things in the GUI, so hopefully this is
 // ok...?
-func MapToVsysEnt(e map[string] []string) *VsysEntryType {
-    if len(e) == 0 {
-        return nil
-    }
+func MapToVsysEnt(e map[string][]string) *VsysEntryType {
+	if len(e) == 0 {
+		return nil
+	}
 
-    i := 0
-    ve := make([]VsysEntry, len(e))
-    for key := range e {
-        ve[i].Serial = key
-        ve[i].Vsys = StrToEnt(e[key])
-        i++
-    }
+	i := 0
+	ve := make([]VsysEntry, len(e))
+	for key := range e {
+		ve[i].Serial = key
+		ve[i].Vsys = StrToEnt(e[key])
+		i++
+	}
 
-    return &VsysEntryType{ve}
+	return &VsysEntryType{ve}
 }
 
 // YesNo returns "yes" on true, "no" on false.
 func YesNo(v bool) string {
-    if v {
-        return "yes"
-    }
-    return "no"
+	if v {
+		return "yes"
+	}
+	return "no"
 }
 
 // AsBool returns true on yes, else false.
 func AsBool(val string) bool {
-    if val == "yes" {
-        return true
-    }
-    return false
+	if val == "yes" {
+		return true
+	}
+	return false
 }
 
 // AsXpath makes an xpath out of the given interface.
 func AsXpath(i interface{}) string {
-    switch val := i.(type) {
-    case string:
-        return val
-    case []string:
-        return fmt.Sprintf("/%s", strings.Join(val, "/"))
-    default:
-        return ""
-    }
+	switch val := i.(type) {
+	case string:
+		return val
+	case []string:
+		return fmt.Sprintf("/%s", strings.Join(val, "/"))
+	default:
+		return ""
+	}
 }
 
 // AsEntryXpath returns the given values as an entry xpath segment.
 func AsEntryXpath(vals []string) string {
-    if len(vals) == 0 || (len(vals) == 1 && vals[0] == "") {
-        return "entry"
-    }
+	if len(vals) == 0 || (len(vals) == 1 && vals[0] == "") {
+		return "entry"
+	}
 
-    var buf bytes.Buffer
+	var buf bytes.Buffer
 
-    buf.WriteString("entry[")
-    for i := range vals {
-        if i != 0 {
-            buf.WriteString(" or ")
-        }
-        buf.WriteString("@name='")
-        buf.WriteString(vals[i])
-        buf.WriteString("'")
-    }
-    buf.WriteString("]")
+	buf.WriteString("entry[")
+	for i := range vals {
+		if i != 0 {
+			buf.WriteString(" or ")
+		}
+		buf.WriteString("@name='")
+		buf.WriteString(vals[i])
+		buf.WriteString("'")
+	}
+	buf.WriteString("]")
 
-    return buf.String()
+	return buf.String()
 }
 
 // AsMemberXpath returns the given values as a member xpath segment.
 func AsMemberXpath(vals []string) string {
-    var buf bytes.Buffer
+	var buf bytes.Buffer
 
-    buf.WriteString("member[")
-    for i := range vals {
-        if i != 0 {
-            buf.WriteString(" or ")
-        }
-        buf.WriteString("text()='")
-        buf.WriteString(vals[i])
-        buf.WriteString("'")
-    }
+	buf.WriteString("member[")
+	for i := range vals {
+		if i != 0 {
+			buf.WriteString(" or ")
+		}
+		buf.WriteString("text()='")
+		buf.WriteString(vals[i])
+		buf.WriteString("'")
+	}
 
-    buf.WriteString("]")
+	buf.WriteString("]")
 
-    return buf.String()
+	return buf.String()
 }
 
 // TemplateXpathPrefix returns the template xpath prefix of the given template name.
 func TemplateXpathPrefix(tmpl, ts string) []string {
-    if tmpl != "" {
-        return []string{
-            "config",
-            "devices",
-            AsEntryXpath([]string{"localhost.localdomain"}),
-            "template",
-            AsEntryXpath([]string{tmpl}),
-        }
-    }
+	if tmpl != "" {
+		return []string{
+			"config",
+			"devices",
+			AsEntryXpath([]string{"localhost.localdomain"}),
+			"template",
+			AsEntryXpath([]string{tmpl}),
+		}
+	}
 
-    return []string{
-        "config",
-        "devices",
-        AsEntryXpath([]string{"localhost.localdomain"}),
-        "template-stack",
-        AsEntryXpath([]string{ts}),
-    }
+	return []string{
+		"config",
+		"devices",
+		AsEntryXpath([]string{"localhost.localdomain"}),
+		"template-stack",
+		AsEntryXpath([]string{ts}),
+	}
 }
 
 // DeviceGroupXpathPrefix returns a device group xpath prefix.
 // If the device group is empty, then the default is "shared".
-func DeviceGroupXpathPrefix(dg string) []string{
-    if dg == "" {
-        dg = "shared"
-    }
+func DeviceGroupXpathPrefix(dg string) []string {
+	if dg == "" {
+		dg = "shared"
+	}
 
-    if dg == "shared" {
-        return []string{"config", "shared"}
-    }
+	if dg == "shared" {
+		return []string{"config", "shared"}
+	}
 
-    return []string{
-        "config",
-        "devices",
-        AsEntryXpath([]string{"localhost.localdomain"}),
-        "device-group",
-        AsEntryXpath([]string{dg}),
-    }
+	return []string{
+		"config",
+		"devices",
+		AsEntryXpath([]string{"localhost.localdomain"}),
+		"device-group",
+		AsEntryXpath([]string{dg}),
+	}
 }
 
 // VsysXpathPrefix returns a vsys xpath prefix.
-func VsysXpathPrefix(vsys string) []string{
-    if vsys == "" {
-        vsys = "vsys1"
-    }
+func VsysXpathPrefix(vsys string) []string {
+	if vsys == "" {
+		vsys = "vsys1"
+	}
 
-    if vsys == "shared" {
-        return []string{"config", "shared"}
-    }
+	if vsys == "shared" {
+		return []string{"config", "shared"}
+	}
 
-    return []string{
-        "config",
-        "devices",
-        AsEntryXpath([]string{"localhost.localdomain"}),
-        "vsys",
-        AsEntryXpath([]string{vsys}),
-    }
+	return []string{
+		"config",
+		"devices",
+		AsEntryXpath([]string{"localhost.localdomain"}),
+		"vsys",
+		AsEntryXpath([]string{vsys}),
+	}
 }
 
 // License defines a license entry.
 type License struct {
-    XMLName xml.Name `xml:"entry"`
-    Feature string `xml:"feature"`
-    Description string `xml:"description"`
-    Serial string `xml:"serial"`
-    Issued string `xml:"issued"`
-    Expires string `xml:"expires"`
-    Expired string `xml:"expired"`
-    AuthCode string `xml:"authcode"`
+	XMLName     xml.Name `xml:"entry"`
+	Feature     string   `xml:"feature"`
+	Description string   `xml:"description"`
+	Serial      string   `xml:"serial"`
+	Issued      string   `xml:"issued"`
+	Expires     string   `xml:"expires"`
+	Expired     string   `xml:"expired"`
+	AuthCode    string   `xml:"authcode"`
 }
 
 // Lock represents either a config lock or a commit lock.
 type Lock struct {
-    XMLName xml.Name `xml:"entry"`
-    Owner string `xml:"name,attr"`
-    Name string `xml:"name"`
-    Type string `xml:"type"`
-    LoggedIn string `xml:"loggedin"`
-    Comment CdataText `xml:"comment"`
+	XMLName  xml.Name  `xml:"entry"`
+	Owner    string    `xml:"name,attr"`
+	Name     string    `xml:"name"`
+	Type     string    `xml:"type"`
+	LoggedIn string    `xml:"loggedin"`
+	Comment  CdataText `xml:"comment"`
 }
 
 // CdataText is for getting CDATA contents of XML docs.
 type CdataText struct {
-    Text string `xml:",cdata"`
+	Text string `xml:",cdata"`
 }
 
 // RawXml is what allows the use of Edit commands on a XPATH without
 // truncating any other child objects that may be attached to it.
 type RawXml struct {
-    Text string `xml:",innerxml"`
+	Text string `xml:",innerxml"`
 }
 
 // CleanRawXml removes extra XML attributes from RawXml objects without
 // requiring us to have to parse everything.
 func CleanRawXml(v string) string {
-    re := regexp.MustCompile(` admin="\S+" dirtyId="\d+" time="\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}"`)
-    return re.ReplaceAllString(v, "")
+	re := regexp.MustCompile(` admin="\S+" dirtyId="\d+" time="\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}"`)
+	return re.ReplaceAllString(v, "")
 }
 
 // JobResponse parses a XML response that includes a job ID.
 type JobResponse struct {
-    XMLName xml.Name `xml:"response"`
-    Id uint `xml:"result>job"`
+	XMLName xml.Name `xml:"response"`
+	Id      uint     `xml:"result>job"`
 }
 
 // BasicJob is a struct for parsing minimal information about a submitted
 // job to PANOS.
 type BasicJob struct {
-    XMLName xml.Name `xml:"response"`
-    Result string `xml:"result>job>result"`
-    Progress uint `xml:"result>job>progress"`
-    Details []string `xml:"result>job>details>line"`
-    Devices []devJob `xml:"result>job>devices>entry"`
+	XMLName  xml.Name `xml:"response"`
+	Result   string   `xml:"result>job>result"`
+	Progress uint     `xml:"result>job>progress"`
+	Details  []string `xml:"result>job>details>line"`
+	Devices  []devJob `xml:"result>job>devices>entry"`
 }
 
 // Internally used by BasicJob for panorama commit-all.
 type devJob struct {
-    Serial string `xml:"serial-no"`
-    Result string `xml:"result"`
+	Serial string `xml:"serial-no"`
+	Result string `xml:"result"`
 }
 
 // These constants are valid move locations to pass to various movement
 // functions (aka - policy management).
 const (
-    MoveSkip = iota
-    MoveBefore
-    MoveDirectlyBefore
-    MoveAfter
-    MoveDirectlyAfter
-    MoveTop
-    MoveBottom
+	MoveSkip = iota
+	MoveBefore
+	MoveDirectlyBefore
+	MoveAfter
+	MoveDirectlyAfter
+	MoveTop
+	MoveBottom
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This implements functionality disucssed in #18 on `AddressObject`, `Service`, `SecurityPolicy` and `NatPolicy` objects. Can later be extended to other object types, but for now I think these 4 provide the biggest benefit since they typically constitute the biggest dataset in production FW configurations, at least in my experience.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Right now to get a full dump (with details) of all objects in the firewall requires getting a list of their names and then making a separate request for each item in the list to obtain the populated objects. Aside from putting a lot of unnecessary stress on the firewall, this is also more verbose and very inefficient. 

Considering that PanOS keeps it's entire configuration as a single xml, it's much more efficient to have a function that retreives an entire subset of a tree corresponding to the given object type, to be parsed into a list of objects clientside. As tested against one of our production firewalls (we are telco company), this PR alone shaves off the time for full export from 12 minutes to 49 seconds.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing code has not been modified. Added code has been integration-tested against one of our production firewalls (`PanOS v8.0.1`). I cannot test Panorama varieties of the code at this time.

## Types of changes

<!--- What types of changes does your code introduce? -->

<!--- Remove any that don't apply: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
