### PR TITLE
adding multi get/show functions to address objects

### DIFF
--- a/objs/addr/entry.go
+++ b/objs/addr/entry.go
@@ -28,57 +28,30 @@ func (o *Entry) Copy(s Entry) {
 /** Structs / functions for normalization. **/
 
 type normalizer interface {
-	Normalize() Entry
+	Normalize() []Entry
 }
 
 type container_v1 struct {
-	Answer entry_v1 `xml:"result>entry"`
+	Answer []entry_v1 `xml:"result>entry"`
 }
 
-func (o *container_v1) Normalize() Entry {
-	ans := Entry{
-		Name:        o.Answer.Name,
-		Description: o.Answer.Description,
-		Tags:        util.MemToStr(o.Answer.Tags),
-	}
-	switch {
-	case o.Answer.IpNetmask != nil:
-		ans.Type = IpNetmask
-		ans.Value = o.Answer.IpNetmask.Value
-	case o.Answer.IpRange != nil:
-		ans.Type = IpRange
-		ans.Value = o.Answer.IpRange.Value
-	case o.Answer.Fqdn != nil:
-		ans.Type = Fqdn
-		ans.Value = o.Answer.Fqdn.Value
+func (o *container_v1) Normalize() []Entry {
+	ans := make([]Entry, 0, len(o.Answer))
+	for i := range o.Answer {
+		ans = append(ans, o.Answer[i].normalize())
 	}
 
 	return ans
 }
 
 type container_v2 struct {
-	Answer entry_v2 `xml:"result>entry"`
+	Answer []entry_v2 `xml:"result>entry"`
 }
 
-func (o *container_v2) Normalize() Entry {
-	ans := Entry{
-		Name:        o.Answer.Name,
-		Description: o.Answer.Description,
-		Tags:        util.MemToStr(o.Answer.Tags),
-	}
-	switch {
-	case o.Answer.IpNetmask != nil:
-		ans.Type = IpNetmask
-		ans.Value = o.Answer.IpNetmask.Value
-	case o.Answer.IpRange != nil:
-		ans.Type = IpRange
-		ans.Value = o.Answer.IpRange.Value
-	case o.Answer.Fqdn != nil:
-		ans.Type = Fqdn
-		ans.Value = o.Answer.Fqdn.Value
-	case o.Answer.IpWildcard != nil:
-		ans.Type = IpWildcard
-		ans.Value = o.Answer.IpWildcard.Value
+func (o *container_v2) Normalize() []Entry {
+	ans := make([]Entry, 0, len(o.Answer))
+	for i := range o.Answer {
+		ans = append(ans, o.Answer[i].normalize())
 	}
 
 	return ans
@@ -117,6 +90,28 @@ func specify_v1(e Entry) interface{} {
 	return ans
 }
 
+func (e *entry_v1) normalize() Entry {
+	ans := Entry{
+		Name:        e.Name,
+		Description: e.Description,
+		Tags:        util.MemToStr(e.Tags),
+	}
+
+	switch {
+	case e.IpNetmask != nil:
+		ans.Type = IpNetmask
+		ans.Value = e.IpNetmask.Value
+	case e.IpRange != nil:
+		ans.Type = IpRange
+		ans.Value = e.IpRange.Value
+	case e.Fqdn != nil:
+		ans.Type = Fqdn
+		ans.Value = e.Fqdn.Value
+	}
+
+	return ans
+}
+
 type entry_v2 struct {
 	XMLName     xml.Name         `xml:"entry"`
 	Name        string           `xml:"name,attr"`
@@ -126,6 +121,31 @@ type entry_v2 struct {
 	IpWildcard  *valType         `xml:"ip-wildcard"`
 	Description string           `xml:"description"`
 	Tags        *util.MemberType `xml:"tag"`
+}
+
+func (e *entry_v2) normalize() Entry {
+	ans := Entry{
+		Name:        e.Name,
+		Description: e.Description,
+		Tags:        util.MemToStr(e.Tags),
+	}
+
+	switch {
+	case e.IpNetmask != nil:
+		ans.Type = IpNetmask
+		ans.Value = e.IpNetmask.Value
+	case e.IpRange != nil:
+		ans.Type = IpRange
+		ans.Value = e.IpRange.Value
+	case e.Fqdn != nil:
+		ans.Type = Fqdn
+		ans.Value = e.Fqdn.Value
+	case e.IpWildcard != nil:
+		ans.Type = IpWildcard
+		ans.Value = e.IpWildcard.Value
+	}
+
+	return ans
 }
 
 func specify_v2(e Entry) interface{} {

--- a/objs/addr/fw.go
+++ b/objs/addr/fw.go
@@ -35,13 +35,33 @@ func (c *FwAddr) ShowList(vsys string) ([]string, error) {
 // Get performs GET to retrieve information for the given address object.
 func (c *FwAddr) Get(vsys, name string) (Entry, error) {
 	c.con.LogQuery("(get) address object %q", name)
-	return c.details(c.con.Get, vsys, name)
+	listing, err := c.details(c.con.Get, vsys, name)
+	if err == nil && len(listing) > 0 {
+		return listing[0], nil
+	}
+	return Entry{}, err
 }
 
-// Get performs SHOW to retrieve information for the given address object.
+// GetAll performs a GET to retrieve objects.
+func (c *FwAddr) GetAll(vsys string) ([]Entry, error) {
+	c.con.LogQuery("(get) all address objects")
+	return c.details(c.con.Get, vsys, "")
+}
+
+// Show performs SHOW to retrieve information for the given address object.
 func (c *FwAddr) Show(vsys, name string) (Entry, error) {
 	c.con.LogQuery("(show) address object %q", name)
-	return c.details(c.con.Show, vsys, name)
+	listing, err := c.details(c.con.Show, vsys, name)
+	if err == nil && len(listing) > 0 {
+		return listing[0], nil
+	}
+	return Entry{}, err
+}
+
+// ShowAll performs SHOW to retrieve all objects.
+func (c *FwAddr) ShowAll(vsys string) ([]Entry, error) {
+	c.con.LogQuery("(show) all address objects")
+	return c.details(c.con.Show, vsys, "")
 }
 
 // Set performs SET to create / update one or more address objects.
@@ -132,12 +152,12 @@ func (c *FwAddr) versioning() (normalizer, func(Entry) interface{}) {
 	}
 }
 
-func (c *FwAddr) details(fn util.Retriever, vsys, name string) (Entry, error) {
+func (c *FwAddr) details(fn util.Retriever, vsys, name string) ([]Entry, error) {
 	path := c.xpath(vsys, []string{name})
 	obj, _ := c.versioning()
 	_, err := fn(path, nil, obj)
 	if err != nil {
-		return Entry{}, err
+		return nil, err
 	}
 	ans := obj.Normalize()
 

--- a/objs/addr/pano.go
+++ b/objs/addr/pano.go
@@ -35,13 +35,33 @@ func (c *PanoAddr) ShowList(dg string) ([]string, error) {
 // Get performs GET to retrieve information for the given address object.
 func (c *PanoAddr) Get(dg, name string) (Entry, error) {
 	c.con.LogQuery("(get) address object %q", name)
-	return c.details(c.con.Get, dg, name)
+	listing, err := c.details(c.con.Get, dg, name)
+	if err == nil && len(listing) > 0 {
+		return listing[0], nil
+	}
+	return Entry{}, err
 }
 
-// Get performs SHOW to retrieve information for the given address object.
+// GetAll performs GET to retrieve all objects.
+func (c *PanoAddr) GetAll(dg string) ([]Entry, error) {
+	c.con.LogQuery("(get) all address objects")
+	return c.details(c.con.Get, dg, "")
+}
+
+// Show performs SHOW to retrieve information for the given address object.
 func (c *PanoAddr) Show(dg, name string) (Entry, error) {
 	c.con.LogQuery("(show) address object %q", name)
-	return c.details(c.con.Show, dg, name)
+	listing, err := c.details(c.con.Show, dg, name)
+	if err == nil && len(listing) > 0 {
+		return listing[0], nil
+	}
+	return Entry{}, err
+}
+
+// ShowAll performs SHOW to retrieve all objects.
+func (c *PanoAddr) ShowAll(dg string) ([]Entry, error) {
+	c.con.LogQuery("(show) all address objects")
+	return c.details(c.con.Show, dg, "")
 }
 
 // Set performs SET to create / update one or more address objects.
@@ -132,12 +152,12 @@ func (c *PanoAddr) versioning() (normalizer, func(Entry) interface{}) {
 	}
 }
 
-func (c *PanoAddr) details(fn util.Retriever, dg, name string) (Entry, error) {
+func (c *PanoAddr) details(fn util.Retriever, dg, name string) ([]Entry, error) {
 	path := c.xpath(dg, []string{name})
 	obj, _ := c.versioning()
 	_, err := fn(path, nil, obj)
 	if err != nil {
-		return Entry{}, err
+		return nil, err
 	}
 	ans := obj.Normalize()
 


### PR DESCRIPTION
@megakoresh

Here's what I'm thinking as far as adding multi- get/show functions in pango, which ended up not needing custom unmarshaling.  Here's what I did:

* change the `container*` structs to always have a list of answers
* move normalization out of the container's normalize and as a function receiver off of `entry*`
* `details()` now returns a list of `Entry`s
* change `Get()` and `Show()` to just return the first element on success from `details()`

The `container*.Normalize()` code is copy/paste for each container, so I feel like there should be a way to not have to copy/paste that code.

Please tell me what you think.