### PR TITLE
Added GetAll and ShowAll to security policies

### DIFF
--- a/poli/security/entry.go
+++ b/poli/security/entry.go
@@ -154,55 +154,63 @@ func (o *Entry) Copy(s Entry) {
 /** Structs / functions for normalization. **/
 
 type normalizer interface {
-	Normalize() Entry
+	Normalize() []Entry
 }
 
 type container_v1 struct {
-	Answer entry_v1 `xml:"result>entry"`
+	Answer []entry_v1 `xml:"result>entry"`
 }
 
-func (o *container_v1) Normalize() Entry {
+func (o *container_v1) Normalize() []Entry {
+	arr := make([]Entry, 0, len(o.Answer))
+	for i := range o.Answer {
+		arr = append(arr, o.Answer[i].normalize())
+	}
+	return arr
+}
+
+func (o *entry_v1) normalize() Entry {
 	ans := Entry{
-		Name:                 o.Answer.Name,
-		Type:                 o.Answer.Type,
-		Description:          o.Answer.Description,
-		Tags:                 util.MemToStr(o.Answer.Tags),
-		SourceZones:          util.MemToStr(o.Answer.SourceZones),
-		DestinationZones:     util.MemToStr(o.Answer.DestinationZones),
-		SourceAddresses:      util.MemToStr(o.Answer.SourceAddresses),
-		NegateSource:         util.AsBool(o.Answer.NegateSource),
-		SourceUsers:          util.MemToStr(o.Answer.SourceUsers),
-		HipProfiles:          util.MemToStr(o.Answer.HipProfiles),
-		DestinationAddresses: util.MemToStr(o.Answer.DestinationAddresses),
-		NegateDestination:    util.AsBool(o.Answer.NegateDestination),
-		Applications:         util.MemToStr(o.Answer.Applications),
-		Services:             util.MemToStr(o.Answer.Services),
-		Categories:           util.MemToStr(o.Answer.Categories),
-		Action:               o.Answer.Action,
-		LogSetting:           o.Answer.LogSetting,
-		LogStart:             util.AsBool(o.Answer.LogStart),
-		LogEnd:               util.AsBool(o.Answer.LogEnd),
-		Disabled:             util.AsBool(o.Answer.Disabled),
-		Schedule:             o.Answer.Schedule,
-		IcmpUnreachable:      util.AsBool(o.Answer.IcmpUnreachable),
+		Name:                 o.Name,
+		Type:                 o.Type,
+		Description:          o.Description,
+		Tags:                 util.MemToStr(o.Tags),
+		SourceZones:          util.MemToStr(o.SourceZones),
+		DestinationZones:     util.MemToStr(o.DestinationZones),
+		SourceAddresses:      util.MemToStr(o.SourceAddresses),
+		NegateSource:         util.AsBool(o.NegateSource),
+		SourceUsers:          util.MemToStr(o.SourceUsers),
+		HipProfiles:          util.MemToStr(o.HipProfiles),
+		DestinationAddresses: util.MemToStr(o.DestinationAddresses),
+		NegateDestination:    util.AsBool(o.NegateDestination),
+		Applications:         util.MemToStr(o.Applications),
+		Services:             util.MemToStr(o.Services),
+		Categories:           util.MemToStr(o.Categories),
+		Action:               o.Action,
+		LogSetting:           o.LogSetting,
+		LogStart:             util.AsBool(o.LogStart),
+		LogEnd:               util.AsBool(o.LogEnd),
+		Disabled:             util.AsBool(o.Disabled),
+		Schedule:             o.Schedule,
+		IcmpUnreachable:      util.AsBool(o.IcmpUnreachable),
 	}
-	if o.Answer.Options != nil {
-		ans.DisableServerResponseInspection = util.AsBool(o.Answer.Options.DisableServerResponseInspection)
+	if o.Options != nil {
+		ans.DisableServerResponseInspection = util.AsBool(o.Options.DisableServerResponseInspection)
 	}
-	if o.Answer.TargetInfo != nil {
-		ans.NegateTarget = util.AsBool(o.Answer.TargetInfo.NegateTarget)
-		ans.Targets = util.VsysEntToMap(o.Answer.TargetInfo.Targets)
+	if o.TargetInfo != nil {
+		ans.NegateTarget = util.AsBool(o.TargetInfo.NegateTarget)
+		ans.Targets = util.VsysEntToMap(o.TargetInfo.Targets)
 	}
-	if o.Answer.ProfileSettings != nil {
-		ans.Group = util.MemToOneStr(o.Answer.ProfileSettings.Group)
-		if o.Answer.ProfileSettings.Profiles != nil {
-			ans.Virus = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.Virus)
-			ans.Spyware = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.Spyware)
-			ans.Vulnerability = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.Vulnerability)
-			ans.UrlFiltering = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.UrlFiltering)
-			ans.FileBlocking = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.FileBlocking)
-			ans.WildFireAnalysis = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.WildFireAnalysis)
-			ans.DataFiltering = util.MemToOneStr(o.Answer.ProfileSettings.Profiles.DataFiltering)
+	if o.ProfileSettings != nil {
+		ans.Group = util.MemToOneStr(o.ProfileSettings.Group)
+		if o.ProfileSettings.Profiles != nil {
+			ans.Virus = util.MemToOneStr(o.ProfileSettings.Profiles.Virus)
+			ans.Spyware = util.MemToOneStr(o.ProfileSettings.Profiles.Spyware)
+			ans.Vulnerability = util.MemToOneStr(o.ProfileSettings.Profiles.Vulnerability)
+			ans.UrlFiltering = util.MemToOneStr(o.ProfileSettings.Profiles.UrlFiltering)
+			ans.FileBlocking = util.MemToOneStr(o.ProfileSettings.Profiles.FileBlocking)
+			ans.WildFireAnalysis = util.MemToOneStr(o.ProfileSettings.Profiles.WildFireAnalysis)
+			ans.DataFiltering = util.MemToOneStr(o.ProfileSettings.Profiles.DataFiltering)
 		}
 	}
 

--- a/poli/security/fw.go
+++ b/poli/security/fw.go
@@ -42,6 +42,12 @@ func (c *FwSecurity) Get(vsys, name string) (Entry, error) {
 	return Entry{}, err
 }
 
+// GetAll performs a GET to retrieve information for all security policies.
+func (c *FwSecurity) GetAll(vsys string) ([]Entry, error) {
+	c.con.LogQuery("(get) all security policies")
+	return c.details(c.con.Get, vsys, "")
+}
+
 // Get performs SHOW to retrieve information for the given security policy.
 func (c *FwSecurity) Show(vsys, name string) (Entry, error) {
 	c.con.LogQuery("(show) security policy %q", name)
@@ -50,6 +56,12 @@ func (c *FwSecurity) Show(vsys, name string) (Entry, error) {
 		return listing[0], nil
 	}
 	return Entry{}, err
+}
+
+// ShowAll performs a GET to retrieve information for all security policies.
+func (c *FwSecurity) ShowAll(vsys string) ([]Entry, error) {
+	c.con.LogQuery("(show) all security policies")
+	return c.details(c.con.Show, vsys, "")
 }
 
 // Set performs SET to create / update one or more security policies.

--- a/poli/security/fw.go
+++ b/poli/security/fw.go
@@ -35,13 +35,21 @@ func (c *FwSecurity) ShowList(vsys string) ([]string, error) {
 // Get performs GET to retrieve information for the given security policy.
 func (c *FwSecurity) Get(vsys, name string) (Entry, error) {
 	c.con.LogQuery("(get) security policy %q", name)
-	return c.details(c.con.Get, vsys, name)
+	listing, err := c.details(c.con.Get, vsys, name)
+	if err == nil && len(listing) > 0 {
+		return listing[0], nil
+	}
+	return Entry{}, err
 }
 
 // Get performs SHOW to retrieve information for the given security policy.
 func (c *FwSecurity) Show(vsys, name string) (Entry, error) {
 	c.con.LogQuery("(show) security policy %q", name)
-	return c.details(c.con.Show, vsys, name)
+	listing, err := c.details(c.con.Show, vsys, name)
+	if err == nil && len(listing) > 0 {
+		return listing[0], nil
+	}
+	return Entry{}, err
 }
 
 // Set performs SET to create / update one or more security policies.
@@ -328,11 +336,11 @@ func (c *FwSecurity) versioning() (normalizer, func(Entry) interface{}) {
 	return &container_v1{}, specify_v1
 }
 
-func (c *FwSecurity) details(fn util.Retriever, vsys, name string) (Entry, error) {
+func (c *FwSecurity) details(fn util.Retriever, vsys, name string) ([]Entry, error) {
 	path := c.xpath(vsys, []string{name})
 	obj, _ := c.versioning()
 	if _, err := fn(path, nil, obj); err != nil {
-		return Entry{}, err
+		return []Entry{}, err
 	}
 	ans := obj.Normalize()
 

--- a/poli/security/pano.go
+++ b/poli/security/pano.go
@@ -42,6 +42,12 @@ func (c *PanoSecurity) Get(dg, base, name string) (Entry, error) {
 	return Entry{}, err
 }
 
+// GetAll performs GET to retrieve all security policies.
+func (c *PanoSecurity) GetAll(dg, base string) ([]Entry, error) {
+	c.con.LogQuery("(get) all security policies")
+	return c.details(c.con.Get, dg, base, "")
+}
+
 // Get performs SHOW to retrieve information for the given security policy.
 func (c *PanoSecurity) Show(dg, base, name string) (Entry, error) {
 	c.con.LogQuery("(show) security policy %q", name)
@@ -50,6 +56,12 @@ func (c *PanoSecurity) Show(dg, base, name string) (Entry, error) {
 		return listing[0], nil
 	}
 	return Entry{}, err
+}
+
+// ShowAll performs SHOW to retrieve all security policies.
+func (c *PanoSecurity) ShowAll(dg, base string) ([]Entry, error) {
+	c.con.LogQuery("(show) all security policies")
+	return c.details(c.con.Show, dg, base, "")
 }
 
 // Set performs SET to create / update one or more security policies.

--- a/poli/security/pano.go
+++ b/poli/security/pano.go
@@ -35,13 +35,21 @@ func (c *PanoSecurity) ShowList(dg, base string) ([]string, error) {
 // Get performs GET to retrieve information for the given security policy.
 func (c *PanoSecurity) Get(dg, base, name string) (Entry, error) {
 	c.con.LogQuery("(get) security policy %q", name)
-	return c.details(c.con.Get, dg, base, name)
+	listing, err := c.details(c.con.Get, dg, base, name)
+	if err == nil && len(listing) > 0 {
+		return listing[0], nil
+	}
+	return Entry{}, err
 }
 
 // Get performs SHOW to retrieve information for the given security policy.
 func (c *PanoSecurity) Show(dg, base, name string) (Entry, error) {
 	c.con.LogQuery("(show) security policy %q", name)
-	return c.details(c.con.Show, dg, base, name)
+	listing, err := c.details(c.con.Show, dg, base, name)
+	if err == nil && len(listing) > 0 {
+		return listing[0], nil
+	}
+	return Entry{}, err
 }
 
 // Set performs SET to create / update one or more security policies.
@@ -328,11 +336,11 @@ func (c *PanoSecurity) versioning() (normalizer, func(Entry) interface{}) {
 	return &container_v1{}, specify_v1
 }
 
-func (c *PanoSecurity) details(fn util.Retriever, dg, base, name string) (Entry, error) {
+func (c *PanoSecurity) details(fn util.Retriever, dg, base, name string) ([]Entry, error) {
 	path := c.xpath(dg, base, []string{name})
 	obj, _ := c.versioning()
 	if _, err := fn(path, nil, obj); err != nil {
-		return Entry{}, err
+		return []Entry{}, err
 	}
 	ans := obj.Normalize()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds GetAll and ShowAll functions to Security rules, closing #23 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These functions are needed when exporting large portions of configuration for performance reasons.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built and tested against some of our production firewalls with over 1.5K rules.
## Types of changes

<!--- What types of changes does your code introduce? -->

<!--- Remove any that don't apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
