### PR TITLE
Redesign of pango commits

### DIFF
--- a/client.go
+++ b/client.go
@@ -1315,13 +1315,19 @@ func addToData(key string, i interface{}, attemptMarshal bool, data *url.Values)
 }
 
 func asString(i interface{}, attemptMarshal bool) (string, error) {
+	if a, ok := i.(fmt.Stringer); ok {
+		return a.String(), nil
+	}
+
+	if b, ok := i.(util.Elementer); ok {
+		i = b.Element()
+	}
+
 	switch val := i.(type) {
-	case string:
-		return val, nil
-	case fmt.Stringer:
-		return val.String(), nil
 	case nil:
 		return "", fmt.Errorf("nil encountered")
+	case string:
+		return val, nil
 	default:
 		if !attemptMarshal {
 			return "", fmt.Errorf("value must be string or fmt.Stringer")

--- a/client_test.go
+++ b/client_test.go
@@ -2,11 +2,13 @@ package pango
 
 import (
 	"bytes"
+	"encoding/xml"
 	"log"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/PaloAltoNetworks/pango/commit"
 	"github.com/PaloAltoNetworks/pango/testdata"
 )
 
@@ -174,5 +176,56 @@ func TestRetrieveApiKey(t *testing.T) {
 		t.Errorf("Failed to retrieve api key: %s", err)
 	} else if c.ApiKey != "secret" {
 		t.Fail()
+	}
+}
+
+func TestAsStringWithString(t *testing.T) {
+	expected := "foobar"
+	val, err := asString(expected, true)
+
+	if err != nil {
+		t.Errorf("Failed asString: %s", err)
+	} else if val != expected {
+		t.Errorf("Expected:%s got:%s", expected, val)
+	}
+}
+
+type StringerCheck struct{}
+
+func (o StringerCheck) String() string { return "hello" }
+
+func TestAsStringWithStringer(t *testing.T) {
+	x := StringerCheck{}
+	expected := x.String()
+
+	val, err := asString(x, true)
+	if err != nil {
+		t.Errorf("Failed asString: %s", err)
+	} else if val != expected {
+		t.Errorf("Expected:%s got:%s", expected, val)
+	}
+}
+
+func TestAsStringWithElementer(t *testing.T) {
+	x := commit.FirewallCommit{
+		Description: "hello",
+	}
+
+	expected, err := xml.Marshal(x.Element())
+	if err != nil {
+		t.Errorf("Failed to marshal firewall commit: %s", err)
+	}
+
+	val, err := asString(x, true)
+	if err != nil {
+		t.Errorf("Failed asString: %s", err)
+	} else if val != string(expected) {
+		t.Errorf("Expected:%s got:%s", expected, val)
+	}
+}
+
+func TestAsStringWithNil(t *testing.T) {
+	if _, err := asString(nil, true); err == nil {
+		t.Errorf("asString() returned no error on nil input")
 	}
 }

--- a/commit/const.go
+++ b/commit/const.go
@@ -1,0 +1,11 @@
+package commit
+
+// Valid values for PanoramaCommitAll.Type.
+const (
+	TypeDeviceGroup       = "device group"
+	TypeTemplate          = "template"
+	TypeTemplateStack     = "template stack"
+	TypeLogCollectorGroup = "log collector group"
+	TypeWildfireAppliance = "wildfire appliance"
+	TypeWildfireCluster   = "wildfire cluster"
+)

--- a/commit/doc.go
+++ b/commit/doc.go
@@ -1,0 +1,4 @@
+/*
+Package commit contains normalizations for firewall and Panorama commits.
+*/
+package commit

--- a/commit/fw.go
+++ b/commit/fw.go
@@ -19,7 +19,7 @@ type FirewallCommit struct {
 }
 
 // Element returns an interface to be marshalled to perform the specified commit.
-func (o *FirewallCommit) Element() interface{} {
+func (o FirewallCommit) Element() interface{} {
 	ans := fwCommit{
 		Description: o.Description,
 	}

--- a/commit/fw.go
+++ b/commit/fw.go
@@ -1,0 +1,74 @@
+package commit
+
+import (
+	"encoding/xml"
+
+	"github.com/PaloAltoNetworks/pango/util"
+)
+
+// FirewallCommit is a normalized object for defining firewall commits.
+//
+// Admins is the list of admins whose changes should be committed.
+type FirewallCommit struct {
+	Description             string
+	Admins                  []string
+	ExcludeDeviceAndNetwork bool
+	ExcludeSharedObjects    bool
+	ExcludePolicyAndObjects bool
+	Force                   bool
+}
+
+// Element returns an interface to be marshalled to perform the specified commit.
+func (o *FirewallCommit) Element() interface{} {
+	ans := fwCommit{
+		Description: o.Description,
+	}
+
+	var p *fwPartialCommit
+	if len(o.Admins) > 0 ||
+		o.ExcludeDeviceAndNetwork || o.ExcludeSharedObjects || o.ExcludePolicyAndObjects {
+		p = &fwPartialCommit{
+			Admins: util.StrToMem(o.Admins),
+		}
+
+		if o.ExcludeDeviceAndNetwork {
+			p.ExcludeDeviceAndNetwork = "excluded"
+		}
+
+		if o.ExcludeSharedObjects {
+			p.ExcludeSharedObjects = "excluded"
+		}
+
+		if o.ExcludePolicyAndObjects {
+			p.ExcludePolicyAndObjects = "excluded"
+		}
+	}
+
+	if o.Force {
+		ans.Force = &fwForce{
+			Partial: p,
+		}
+	} else {
+		ans.Partial = p
+	}
+
+	return ans
+}
+
+type fwCommit struct {
+	XMLName     xml.Name         `xml:"commit"`
+	Description string           `xml:"description,omitempty"`
+	Force       *fwForce         `xml:"force"`
+	Partial     *fwPartialCommit `xml:"partial"`
+}
+
+type fwForce struct {
+	Partial *fwPartialCommit `xml:"partial"`
+}
+
+type fwPartialCommit struct {
+	Admins                  *util.MemberType `xml:"admin"`
+	ExcludeDeviceAndNetwork string           `xml:"device-and-network,omitempty"`
+	ExcludeSharedObjects    string           `xml:"shared-object,omitempty"`
+	ExcludePolicyAndObjects string           `xml:"policy-and-objects,omitempty"`
+}

--- a/commit/fw_test.go
+++ b/commit/fw_test.go
@@ -1,0 +1,145 @@
+package commit
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+func TestFwNormalCommit(t *testing.T) {
+	expected := `<commit><description>Hello</description></commit>`
+
+	c := FirewallCommit{
+		Description: "Hello",
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPartialCommitWithAdmins(t *testing.T) {
+	s := []string{
+		"<commit>",
+		"<description>example</description>",
+		"<partial><admin>",
+		"<member>a1</member>",
+		"<member>a2</member>",
+		"</admin></partial>",
+		"</commit>",
+	}
+
+	expected := strings.Join(s, "")
+
+	c := FirewallCommit{
+		Description: "example",
+		Admins:      []string{"a1", "a2"},
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPartialExcludeDeviceAndNetwork(t *testing.T) {
+	s := []string{
+		"<commit>",
+		"<description>example</description>",
+		"<partial>",
+		"<device-and-network>excluded</device-and-network>",
+		"</partial>",
+		"</commit>",
+	}
+
+	expected := strings.Join(s, "")
+
+	c := FirewallCommit{
+		Description:             "example",
+		ExcludeDeviceAndNetwork: true,
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPartialExcludePolicyAndObject(t *testing.T) {
+	s := []string{
+		"<commit>",
+		"<description>example</description>",
+		"<partial>",
+		"<policy-and-objects>excluded</policy-and-objects>",
+		"</partial>",
+		"</commit>",
+	}
+
+	expected := strings.Join(s, "")
+
+	c := FirewallCommit{
+		Description:             "example",
+		ExcludePolicyAndObjects: true,
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPartialExcludeShared(t *testing.T) {
+	s := []string{
+		"<commit>",
+		"<description>example</description>",
+		"<partial>",
+		"<shared-object>excluded</shared-object>",
+		"</partial>",
+		"</commit>",
+	}
+
+	expected := strings.Join(s, "")
+
+	c := FirewallCommit{
+		Description:          "example",
+		ExcludeSharedObjects: true,
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestFullPartial(t *testing.T) {
+	s := []string{
+		"<commit>",
+		"<description>check</description>",
+		"<partial>",
+		"<admin>",
+		"<member>user1</member>",
+		"<member>user2</member>",
+		"</admin>",
+		"<device-and-network>excluded</device-and-network>",
+		"<shared-object>excluded</shared-object>",
+		"<policy-and-objects>excluded</policy-and-objects>",
+		"</partial>",
+		"</commit>",
+	}
+
+	expected := strings.Join(s, "")
+
+	c := FirewallCommit{
+		Description:             "check",
+		Admins:                  []string{"user1", "user2"},
+		ExcludeDeviceAndNetwork: true,
+		ExcludeSharedObjects:    true,
+		ExcludePolicyAndObjects: true,
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}

--- a/commit/pano.go
+++ b/commit/pano.go
@@ -1,0 +1,219 @@
+package commit
+
+import (
+	"encoding/xml"
+
+	"github.com/PaloAltoNetworks/pango/util"
+)
+
+// PanoramaCommit is a normalized Panorama commit.
+//
+// Admins is the list of admins whose changes should be committed.
+type PanoramaCommit struct {
+	Description             string
+	Admins                  []string
+	DeviceGroups            []string
+	Templates               []string
+	TemplateStacks          []string
+	WildfireAppliances      []string
+	WildfireClusters        []string
+	LogCollectors           []string
+	LogCollectorGroups      []string
+	ExcludeDeviceAndNetwork bool
+	ExcludeSharedObjects    bool
+	Force                   bool
+}
+
+// Element returns an interface to be marshalled to perform the specified commit.
+func (o *PanoramaCommit) Element() interface{} {
+	ans := panoCommit{
+		Description: o.Description,
+	}
+
+	var p *panoPartialCommit
+	if len(o.Admins) > 0 || len(o.DeviceGroups) > 0 ||
+		len(o.WildfireAppliances) > 0 || len(o.WildfireClusters) > 0 ||
+		len(o.LogCollectors) > 0 || len(o.LogCollectorGroups) > 0 ||
+		len(o.Templates) > 0 || len(o.TemplateStacks) > 0 ||
+		o.ExcludeDeviceAndNetwork || o.ExcludeSharedObjects {
+		p = &panoPartialCommit{
+			Admins:             util.StrToMem(o.Admins),
+			DeviceGroups:       util.StrToMem(o.DeviceGroups),
+			Templates:          util.StrToMem(o.Templates),
+			TemplateStacks:     util.StrToMem(o.TemplateStacks),
+			WildfireAppliances: util.StrToMem(o.WildfireAppliances),
+			WildfireClusters:   util.StrToMem(o.WildfireClusters),
+			LogCollectors:      util.StrToMem(o.LogCollectors),
+			LogCollectorGroups: util.StrToMem(o.LogCollectorGroups),
+		}
+
+		if o.ExcludeDeviceAndNetwork {
+			p.ExcludeDeviceAndNetwork = "excluded"
+		}
+
+		if o.ExcludeSharedObjects {
+			p.ExcludeSharedObjects = "excluded"
+		}
+	}
+
+	if o.Force {
+		ans.Force = &panoForce{
+			Partial: p,
+		}
+	} else {
+		ans.Partial = p
+	}
+
+	return ans
+}
+
+type panoCommit struct {
+	XMLName     xml.Name           `xml:"commit"`
+	Description string             `xml:"description,omitempty"`
+	Force       *panoForce         `xml:"force"`
+	Partial     *panoPartialCommit `xml:"partial"`
+}
+
+type panoForce struct {
+	Partial *panoPartialCommit `xml:"partial"`
+}
+
+type panoPartialCommit struct {
+	Admins                  *util.MemberType `xml:"admin"`
+	DeviceGroups            *util.MemberType `xml:"device-group"`
+	Templates               *util.MemberType `xml:"template"`
+	TemplateStacks          *util.MemberType `xml:"template-stack"`
+	WildfireAppliances      *util.MemberType `xml:"wildfire-appliance"`
+	WildfireClusters        *util.MemberType `xml:"wildfire-appliance-cluster"`
+	LogCollectors           *util.MemberType `xml:"log-collector"`
+	LogCollectorGroups      *util.MemberType `xml:"log-collector-group"`
+	ExcludeDeviceAndNetwork string           `xml:"device-and-network,omitempty"`
+	ExcludeSharedObjects    string           `xml:"shared-object,omitempty"`
+}
+
+/*
+PanoramaCommitAll is a normalized Panorama commit-all.
+
+Depending on the type of commit specified, only certain parameters of this
+object are used.
+
+Regardless of the type given, all commits will use the Description  and Name params.
+
+TypeDeviceGroup types uses Devices, IncludeTemplate, and ForceTemplateValues.
+
+TypeTemplate and TypeTemplateStack uses Devices and ForceTemplateValues.
+*/
+type PanoramaCommitAll struct {
+	Type                string
+	Name                string
+	Description         string
+	IncludeTemplate     bool
+	ForceTemplateValues bool
+	Devices             []string
+}
+
+// Element returns an interface to be marshalled to perform the specified commit.
+func (o *PanoramaCommitAll) Element() interface{} {
+	var ans panoCommitAll
+
+	switch o.Type {
+	case TypeDeviceGroup:
+		ans = panoCommitAll{
+			DeviceGroup: &pcaDeviceGroup{
+				DgInfo: pcaDgInfo{
+					Entry: pcaDgInfoEntry{
+						Name:    o.Name,
+						Devices: util.StrToEnt(o.Devices),
+					},
+				},
+				Description:         o.Description,
+				IncludeTemplate:     util.YesNo(o.IncludeTemplate),
+				ForceTemplateValues: util.YesNo(o.ForceTemplateValues),
+			},
+		}
+	case TypeTemplate:
+		ans = panoCommitAll{
+			Template: &pcaTemplate{
+				Name:                o.Name,
+				Description:         o.Description,
+				ForceTemplateValues: util.YesNo(o.ForceTemplateValues),
+				Devices:             util.StrToMem(o.Devices),
+			},
+		}
+	case TypeTemplateStack:
+		ans = panoCommitAll{
+			TemplateStack: &pcaTemplate{
+				Name:                o.Name,
+				Description:         o.Description,
+				ForceTemplateValues: util.YesNo(o.ForceTemplateValues),
+				Devices:             util.StrToMem(o.Devices),
+			},
+		}
+	case TypeLogCollectorGroup:
+		ans = panoCommitAll{
+			LogCollectorGroup: &pcaLogCollectorGroup{
+				Name:        o.Name,
+				Description: o.Description,
+			},
+		}
+	case TypeWildfireAppliance:
+		ans = panoCommitAll{
+			Wildfire: &pcaWildfire{
+				Appliance:   o.Name,
+				Description: o.Description,
+			},
+		}
+	case TypeWildfireCluster:
+		ans = panoCommitAll{
+			Wildfire: &pcaWildfire{
+				Cluster:     o.Name,
+				Description: o.Description,
+			},
+		}
+	}
+
+	return ans
+}
+
+type panoCommitAll struct {
+	XMLName           xml.Name              `xml:"commit-all"`
+	DeviceGroup       *pcaDeviceGroup       `xml:"shared-policy"`
+	Template          *pcaTemplate          `xml:"template"`
+	TemplateStack     *pcaTemplate          `xml:"template-stack"`
+	LogCollectorGroup *pcaLogCollectorGroup `xml:"log-collector-config"`
+	Wildfire          *pcaWildfire          `xml:"wildfire-appliance-config"`
+}
+
+type pcaDeviceGroup struct {
+	DgInfo              pcaDgInfo `xml:"device-group"`
+	Description         string    `xml:"description,omitempty"`
+	IncludeTemplate     string    `xml:"include-template"`
+	ForceTemplateValues string    `xml:"force-template-values"`
+}
+
+type pcaDgInfo struct {
+	Entry pcaDgInfoEntry `xml:"entry"`
+}
+
+type pcaDgInfoEntry struct {
+	Name    string          `xml:"name,attr"`
+	Devices *util.EntryType `xml:"devices"`
+}
+
+type pcaTemplate struct {
+	Name                string           `xml:"name"`
+	Description         string           `xml:"description,omitempty"`
+	Devices             *util.MemberType `xml:"device"`
+	ForceTemplateValues string           `xml:"force-template-values"`
+}
+
+type pcaLogCollectorGroup struct {
+	Name        string `xml:"log-collector-group"`
+	Description string `xml:"description,omitempty"`
+}
+
+type pcaWildfire struct {
+	Description string `xml:"description,omitempty"`
+	Appliance   string `xml:"wildfire-appliance,omitempty"`
+	Cluster     string `xml:"wildfire-appliance-cluster,omitempty"`
+}

--- a/commit/pano.go
+++ b/commit/pano.go
@@ -25,7 +25,7 @@ type PanoramaCommit struct {
 }
 
 // Element returns an interface to be marshalled to perform the specified commit.
-func (o *PanoramaCommit) Element() interface{} {
+func (o PanoramaCommit) Element() interface{} {
 	ans := panoCommit{
 		Description: o.Description,
 	}
@@ -113,7 +113,7 @@ type PanoramaCommitAll struct {
 }
 
 // Element returns an interface to be marshalled to perform the specified commit.
-func (o *PanoramaCommitAll) Element() interface{} {
+func (o PanoramaCommitAll) Element() interface{} {
 	var ans panoCommitAll
 
 	switch o.Type {

--- a/commit/pano_test.go
+++ b/commit/pano_test.go
@@ -1,0 +1,254 @@
+package commit
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+func TestPanoNormalCommit(t *testing.T) {
+	expected := `<commit><description>Hello</description></commit>`
+
+	c := PanoramaCommit{
+		Description: "Hello",
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPanoForcePartialCommit(t *testing.T) {
+	s := []string{
+		"<commit>",
+		"<description>forced partial commit</description>",
+		"<force>",
+		"<partial>",
+		"<device-group><member>dg1</member></device-group>",
+		"<shared-object>excluded</shared-object>",
+		"</partial>",
+		"</force>",
+		"</commit>",
+	}
+	expected := strings.Join(s, "")
+
+	c := PanoramaCommit{
+		Description:          "forced partial commit",
+		DeviceGroups:         []string{"dg1"},
+		ExcludeSharedObjects: true,
+		Force:                true,
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPanoFullCommit(t *testing.T) {
+	s := []string{
+		"<commit>",
+		"<description>full</description>",
+		"<partial>",
+		"<admin><member>admin1</member><member>admin2</member></admin>",
+		"<device-group><member>dg1</member></device-group>",
+		"<template><member>tmpl1</member></template>",
+		"<template-stack><member>ts1</member></template-stack>",
+		"<wildfire-appliance><member>wfa1</member></wildfire-appliance>",
+		"<wildfire-appliance-cluster><member>wfc1</member></wildfire-appliance-cluster>",
+		"<log-collector><member>lc1</member></log-collector>",
+		"<log-collector-group><member>lcg1</member></log-collector-group>",
+		"<device-and-network>excluded</device-and-network>",
+		"<shared-object>excluded</shared-object>",
+		"</partial>",
+		"</commit>",
+	}
+	expected := strings.Join(s, "")
+
+	c := PanoramaCommit{
+		Description:             "full",
+		Admins:                  []string{"admin1", "admin2"},
+		DeviceGroups:            []string{"dg1"},
+		Templates:               []string{"tmpl1"},
+		TemplateStacks:          []string{"ts1"},
+		WildfireAppliances:      []string{"wfa1"},
+		WildfireClusters:        []string{"wfc1"},
+		LogCollectors:           []string{"lc1"},
+		LogCollectorGroups:      []string{"lcg1"},
+		ExcludeDeviceAndNetwork: true,
+		ExcludeSharedObjects:    true,
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPanoBlankCommitAll(t *testing.T) {
+	s := []string{
+		"<commit-all>",
+		"</commit-all>",
+	}
+	expected := strings.Join(s, "")
+
+	c := PanoramaCommitAll{}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPanoCommitAllDeviceGroup(t *testing.T) {
+	s := []string{
+		"<commit-all>",
+		"<shared-policy>",
+		"<device-group>",
+		"<entry name=\"foo\"><devices><entry name=\"d1\"></entry></devices></entry>",
+		"</device-group>",
+		"<description>device group</description>",
+		"<include-template>yes</include-template>",
+		"<force-template-values>no</force-template-values>",
+		"</shared-policy>",
+		"</commit-all>",
+	}
+	expected := strings.Join(s, "")
+
+	c := PanoramaCommitAll{
+		Type:            TypeDeviceGroup,
+		Name:            "foo",
+		Description:     "device group",
+		Devices:         []string{"d1"},
+		IncludeTemplate: true,
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPanoCommitAllTemplate(t *testing.T) {
+	s := []string{
+		"<commit-all>",
+		"<template>",
+		"<name>tmpl1</name>",
+		"<description>template</description>",
+		"<device><member>12321</member></device>",
+		"<force-template-values>yes</force-template-values>",
+		"</template>",
+		"</commit-all>",
+	}
+	expected := strings.Join(s, "")
+
+	c := PanoramaCommitAll{
+		Type:                TypeTemplate,
+		Name:                "tmpl1",
+		Description:         "template",
+		Devices:             []string{"12321"},
+		ForceTemplateValues: true,
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPanoCommitAllTemplateStack(t *testing.T) {
+	s := []string{
+		"<commit-all>",
+		"<template-stack>",
+		"<name>ts1</name>",
+		"<description>template stack</description>",
+		"<device><member>12321</member></device>",
+		"<force-template-values>yes</force-template-values>",
+		"</template-stack>",
+		"</commit-all>",
+	}
+	expected := strings.Join(s, "")
+
+	c := PanoramaCommitAll{
+		Type:                TypeTemplateStack,
+		Name:                "ts1",
+		Description:         "template stack",
+		Devices:             []string{"12321"},
+		ForceTemplateValues: true,
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPanoCommitAllLogCollectorGroup(t *testing.T) {
+	s := []string{
+		"<commit-all>",
+		"<log-collector-config>",
+		"<log-collector-group>lcg1</log-collector-group>",
+		"<description>log collector</description>",
+		"</log-collector-config>",
+		"</commit-all>",
+	}
+	expected := strings.Join(s, "")
+
+	c := PanoramaCommitAll{
+		Type:        TypeLogCollectorGroup,
+		Name:        "lcg1",
+		Description: "log collector",
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPanoCommitAllWildfireAppliance(t *testing.T) {
+	s := []string{
+		"<commit-all>",
+		"<wildfire-appliance-config>",
+		"<description>wf check</description>",
+		"<wildfire-appliance>wfa1</wildfire-appliance>",
+		"</wildfire-appliance-config>",
+		"</commit-all>",
+	}
+	expected := strings.Join(s, "")
+
+	c := PanoramaCommitAll{
+		Type:        TypeWildfireAppliance,
+		Name:        "wfa1",
+		Description: "wf check",
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}
+
+func TestPanoCommitAllWildfireCluster(t *testing.T) {
+	s := []string{
+		"<commit-all>",
+		"<wildfire-appliance-config>",
+		"<description>wf check</description>",
+		"<wildfire-appliance-cluster>wfc1</wildfire-appliance-cluster>",
+		"</wildfire-appliance-config>",
+		"</commit-all>",
+	}
+	expected := strings.Join(s, "")
+
+	c := PanoramaCommitAll{
+		Type:        TypeWildfireCluster,
+		Name:        "wfc1",
+		Description: "wf check",
+	}
+
+	b, _ := xml.Marshal(c.Element())
+	if expected != string(b) {
+		t.Errorf("Expected(%s) got(%s)", expected, b)
+	}
+}

--- a/pano.go
+++ b/pano.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/PaloAltoNetworks/pango/util"
-
 	// Various namespace imports.
 	"github.com/PaloAltoNetworks/pango/dev"
 	"github.com/PaloAltoNetworks/pango/licen"

--- a/pano.go
+++ b/pano.go
@@ -69,50 +69,6 @@ func (c *Panorama) Initialize() error {
 	return nil
 }
 
-// CommitAll performs a Panorama commit-all.
-//
-// Param dg is the device group you want to commit-all on.  Note that all other
-// params are ignored / unused if the device group is left empty.
-//
-// Param desc is the optional commit description message you want associated
-// with the commit.
-//
-// Param serials is the list of serial numbers you want to limit the commit-all
-// to that are also in the device group dg.
-//
-// Param tmpl should be true if you want to push template config as well.
-//
-// Param sync should be true if you want this function to block until the
-// commit job completes.
-//
-// Commits result in a job being submitted to the backend.  The job ID and
-// if an error was encountered or not are returned from this function.
-func (c *Panorama) CommitAll(dg, desc string, serials []string, tmpl, sync bool) (uint, error) {
-	c.LogAction("(commit-all) %q", desc)
-
-	req := panoDgCommit{}
-	if dg != "" {
-		sp := sharedPolicy{
-			Description:  desc,
-			WithTemplate: util.YesNo(tmpl),
-			Dg: deviceGroup{
-				Entry: deviceGroupEntry{
-					Name:    dg,
-					Devices: util.StrToEnt(serials),
-				},
-			},
-		}
-		req.Policy = &sp
-	}
-
-	job, _, err := c.CommitConfig(req, "all", nil)
-	if err != nil || !sync || job == 0 {
-		return job, err
-	}
-
-	return job, c.WaitForJob(job, nil)
-}
-
 // CreateVmAuthKey creates a VM auth key to bootstrap a VM-Series firewall.
 //
 // VM auth keys are only valid for the number of hours specified.
@@ -290,26 +246,4 @@ func (c *Panorama) initPlugins() {
 			"downloaded":       data.Downloaded,
 		})
 	}
-}
-
-/** Internal structs / functions **/
-
-type panoDgCommit struct {
-	XMLName xml.Name      `xml:"commit-all"`
-	Policy  *sharedPolicy `xml:"shared-policy"`
-}
-
-type sharedPolicy struct {
-	Dg           deviceGroup `xml:"device-group"`
-	Description  string      `xml:"description,omitempty"`
-	WithTemplate string      `xml:"include-template"`
-}
-
-type deviceGroup struct {
-	Entry deviceGroupEntry `xml:"entry"`
-}
-
-type deviceGroupEntry struct {
-	Name    string          `xml:"name,attr"`
-	Devices *util.EntryType `xml:"devices"`
 }

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -34,14 +34,16 @@ type MockClient struct {
 	Extras        interface{}
 }
 
-func (c *MockClient) String() string                                              { return "mock" }
-func (c *MockClient) Versioning() version.Number                                  { return c.Version }
-func (c *MockClient) Plugins() []map[string]string                                { return c.Plugin }
-func (c *MockClient) LogAction(f string, a ...interface{})                        {}
-func (c *MockClient) LogQuery(f string, a ...interface{})                         {}
-func (c *MockClient) LogOp(f string, a ...interface{})                            {}
-func (c *MockClient) LogUid(f string, a ...interface{})                           {}
-func (c *MockClient) Commit(d string, e []string, f, g, h, i bool) (uint, error)  { return 0, nil }
+func (c *MockClient) String() string                       { return "mock" }
+func (c *MockClient) Versioning() version.Number           { return c.Version }
+func (c *MockClient) Plugins() []map[string]string         { return c.Plugin }
+func (c *MockClient) LogAction(f string, a ...interface{}) {}
+func (c *MockClient) LogQuery(f string, a ...interface{})  {}
+func (c *MockClient) LogOp(f string, a ...interface{})     {}
+func (c *MockClient) LogUid(f string, a ...interface{})    {}
+func (c *MockClient) Commit(d interface{}, e string, f interface{}) (uint, []byte, error) {
+	return 0, nil, nil
+}
 func (c *MockClient) PositionFirstEntity(d int, e, f string, g, h []string) error { return nil }
 
 func (c *MockClient) Op(req interface{}, vsys string, extras interface{}, ans interface{}) ([]byte, error) {

--- a/util/util.go
+++ b/util/util.go
@@ -53,7 +53,7 @@ type XapiClient interface {
 	VsysImport(string, string, string, string, []string) error
 	VsysUnimport(string, string, string, []string) error
 	WaitForJob(uint, interface{}) error
-	Commit(string, []string, bool, bool, bool, bool) (uint, error)
+	Commit(interface{}, string, interface{}) (uint, []byte, error)
 	PositionFirstEntity(int, string, string, []string, []string) error
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -31,6 +31,11 @@ const (
 	VlanImport          = "vlan"
 )
 
+// Elementer is an interface for commits.
+type Elementer interface {
+	Element() interface{}
+}
+
 // XapiClient is the interface that describes an pango.Client.
 type XapiClient interface {
 	String() string


### PR DESCRIPTION
THIS IS A BREAKING CHANGE.

Panorama commits were more varied than was reflected in the code, and the XML sent for forced firewall commits was just wrong.  This commit more fully fleshes out what pango is capable of sending to PAN-OS.

Commits for firewall now look like this:

```golang
cmd := commit.FirewallCommit{
    Description: "My description",
    Admins: []string{"admin1", "admin2"},
}

jobId, _, err := fw.Commit(cmd, "", nil)
if err != nil {
    // Error submitting the job.
} else if jobId == 0 {
    fmt.Printf("no commit needed")
} else if err = fw.WaitForJob(jobId, nil); err != nil {
    // Commit failed.
}
```

Panorama commits are very similar to the above, just with more params supported for partial commits.  Panorama commit-all is a bit different.  You now have to specify the action of `all` yourself when invoking `Client.Commit()`:

```golang
// Do multiple commit-alls, and poll for them to finish.
cmds := []commit.PanoramaCommitAll{
    commit.PanoramaCommitAll{
        Type: commit.TypeTemplate,
        Name: "myTemplate",
        Description: "Commit all just this one template",
    },
    commit.PanoramaCommitAll{
        Type: commit.TypeTemplate,
        Name: "secondTemplate",
        Description: "Commit all just to this template as well",
    },
    commit.PanoramaCommitAll{
        Type: commmit.TypeLogCollectorGroup,
        Name: "logCollectorGroup1",
        Description: "And commit all to just this one log collector group",
    },
}

// First submit all the commit-alls to PAN-OS.
jobs := make([]uint, len(cmds))
for n, cmd := range cmds {
    jobId, _, err := pano.Commit(cmd, "all", nil)
    if err != nil {
        log.Printf("Failed to submit job index %d: %s", n, err)
        return err
    }
    jobs[n] = jobId
}

// Now wait for them to finish.
for n, jobId := range jobs {
    if err := pano.WaitForJob(jobId, nil); err != nil {
        log.Printf("Failed commit for commit index %d: %s", n, err)
        return err
    }
}
```