### PR TITLE
Respect proxy configuration in environment.

### DIFF
--- a/client.go
+++ b/client.go
@@ -994,6 +994,7 @@ func (c *Client) initCon() error {
 	// Setup the https client
 	if c.Transport == nil {
 		c.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: !c.VerifyCertificate,
 			},


### PR DESCRIPTION
Allow pango client to use a http proxy when HTTP_PROXY, HTTPS_PROXY env vars are set.

Necessary for those of us stuck running terraform behind a corporate proxy to automate panos devices on the outside.

## Description

For client-to-device communications, pango will not make use of an http proxy even if HTTP_PROXY and/or HTTPS_PROXY environment variables are set.

This change modifies the http client transport configuration to respect standard proxy environment variables, if set.  Seems reasonable; the default go http client transport enables this by default.

## Motivation and Context

To the best of my knowledge, it's not possible to run terraform with panos provider against a panos device on the other side of an http proxy.  Many environments (mine included) unfortunately have this restriction, with a non-transparent http proxy that all http clients must explicitly be aware of and funnel traffic through.

As a specific use case, this change will make it possible for us to drive automated configuration of cloud-based vm-series deployments via orchestration running inside our internal network environment.

## How Has This Been Tested?

* existing test suites pass.  I have added no new tests... 
* terraform-provider-panos built against this change respects standard proxy environment variables and can successfully communicate with target panos devices over the proxy

## Types of changes

<!--- What types of changes does your code introduce? -->

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
