### PR TITLE
fix(router entry): do deep copy of Interfaces slice

### DIFF
--- a/netw/routing/router/entry.go
+++ b/netw/routing/router/entry.go
@@ -87,7 +87,8 @@ func (o *Entry) Defaults() {
 // Copy copies the information from source Entry `s` to this object.  As the
 // Name field relates to the XPATH of this object, this field is not copied.
 func (o *Entry) Copy(s Entry) {
-	o.Interfaces = s.Interfaces
+	o.Interfaces = make([]string, len(s.Interfaces))
+	copy(o.Interfaces, s.Interfaces)
 	o.StaticDist = s.StaticDist
 	o.StaticIpv6Dist = s.StaticIpv6Dist
 	o.OspfIntDist = s.OspfIntDist


### PR DESCRIPTION
## Description

When doing a copy a `router` entry, the `Interfaces` attribute is a string slice and it was not deeply copied, so when changing something in this slice later, affects both objects.

## Motivation and Context

Implement a deep copy of the `router` entry by doing a copy of the `Interfaces` slice

## How Has This Been Tested?

Doing the same change and validating that the change is contained to the proper object

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
