### PR TITLE
Deep copy of Redistribute Profile string slices

### DIFF
--- a/netw/routing/profile/redist/ipv4/entry.go
+++ b/netw/routing/profile/redist/ipv4/entry.go
@@ -27,15 +27,24 @@ type Entry struct {
 func (o *Entry) Copy(s Entry) {
 	o.Priority = s.Priority
 	o.Action = s.Action
-	o.Types = s.Types
-	o.Interfaces = s.Interfaces
-	o.Destinations = s.Destinations
-	o.NextHops = s.NextHops
-	o.OspfPathTypes = s.OspfPathTypes
-	o.OspfAreas = s.OspfAreas
-	o.OspfTags = s.OspfTags
-	o.BgpCommunities = s.BgpCommunities
-	o.BgpExtendedCommunities = s.BgpExtendedCommunities
+	o.Types = make([]string, len(s.Types))
+	copy(o.Types, s.Types)
+	o.Interfaces = make([]string, len(s.Interfaces))
+	copy(o.Interfaces, s.Interfaces)
+	o.Destinations = make([]string, len(s.Destinations))
+	copy(o.Destinations, s.Destinations)
+	o.NextHops = make([]string, len(s.NextHops))
+	copy(o.NextHops, s.NextHops)
+	o.OspfPathTypes = make([]string, len(s.OspfPathTypes))
+	copy(o.OspfPathTypes, s.OspfPathTypes)
+	o.OspfAreas = make([]string, len(s.OspfAreas))
+	copy(o.OspfAreas, s.OspfAreas)
+	o.OspfTags = make([]string, len(s.OspfTags))
+	copy(o.OspfTags, s.OspfTags)
+	o.BgpCommunities = make([]string, len(s.BgpCommunities))
+	copy(o.BgpCommunities, s.BgpCommunities)
+	o.BgpExtendedCommunities = make([]string, len(s.BgpExtendedCommunities))
+	copy(o.BgpExtendedCommunities, s.BgpExtendedCommunities)
 }
 
 /** Structs / functions for this namespace. **/

--- a/netw/routing/profile/redist/ipv4/entry.go
+++ b/netw/routing/profile/redist/ipv4/entry.go
@@ -27,24 +27,60 @@ type Entry struct {
 func (o *Entry) Copy(s Entry) {
 	o.Priority = s.Priority
 	o.Action = s.Action
-	o.Types = make([]string, len(s.Types))
-	copy(o.Types, s.Types)
-	o.Interfaces = make([]string, len(s.Interfaces))
-	copy(o.Interfaces, s.Interfaces)
-	o.Destinations = make([]string, len(s.Destinations))
-	copy(o.Destinations, s.Destinations)
-	o.NextHops = make([]string, len(s.NextHops))
-	copy(o.NextHops, s.NextHops)
-	o.OspfPathTypes = make([]string, len(s.OspfPathTypes))
-	copy(o.OspfPathTypes, s.OspfPathTypes)
-	o.OspfAreas = make([]string, len(s.OspfAreas))
-	copy(o.OspfAreas, s.OspfAreas)
-	o.OspfTags = make([]string, len(s.OspfTags))
-	copy(o.OspfTags, s.OspfTags)
-	o.BgpCommunities = make([]string, len(s.BgpCommunities))
-	copy(o.BgpCommunities, s.BgpCommunities)
-	o.BgpExtendedCommunities = make([]string, len(s.BgpExtendedCommunities))
-	copy(o.BgpExtendedCommunities, s.BgpExtendedCommunities)
+	if s.Types == nil {
+		o.Types = nil
+	} else {
+		o.Types = make([]string, len(s.Types))
+		copy(o.Types, s.Types)
+	}
+	if s.Interfaces == nil {
+		o.Interfaces = nil
+	} else {
+		o.Interfaces = make([]string, len(s.Interfaces))
+		copy(o.Interfaces, s.Interfaces)
+	}
+	if s.Destinations == nil {
+		o.Destinations = nil
+	} else {
+		o.Destinations = make([]string, len(s.Destinations))
+		copy(o.Destinations, s.Destinations)
+	}
+	if s.NextHops == nil {
+		o.NextHops = nil
+	} else {
+		o.NextHops = make([]string, len(s.NextHops))
+		copy(o.NextHops, s.NextHops)
+	}
+	if s.OspfPathTypes == nil {
+		o.OspfPathTypes = nil
+	} else {
+		o.OspfPathTypes = make([]string, len(s.OspfPathTypes))
+		copy(o.OspfPathTypes, s.OspfPathTypes)
+	}
+	if s.OspfAreas == nil {
+		o.OspfAreas = nil
+	} else {
+		o.OspfAreas = make([]string, len(s.OspfAreas))
+		copy(o.OspfAreas, s.OspfAreas)
+	}
+	if s.OspfTags == nil {
+		o.OspfTags = nil
+	} else {
+		o.OspfTags = make([]string, len(s.OspfTags))
+		copy(o.OspfTags, s.OspfTags)
+	}
+	if s.BgpCommunities == nil {
+		o.BgpCommunities = nil
+	} else {
+		o.BgpCommunities = make([]string, len(s.BgpCommunities))
+		copy(o.BgpCommunities, s.BgpCommunities)
+	}
+	if s.BgpExtendedCommunities == nil {
+		o.BgpExtendedCommunities = nil
+	} else {
+		o.BgpExtendedCommunities = make([]string, len(s.BgpExtendedCommunities))
+		copy(o.BgpExtendedCommunities, s.BgpExtendedCommunities)
+	}
 }
 
 /** Structs / functions for this namespace. **/


### PR DESCRIPTION
## Description

When copying string slices from objects the object is not recreated, it shares the memory.

## Motivation and Context

Make the Copy working without sharing memory.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
