### PR TITLE
fix(ha): o.StateSync.Ha2KeepAlive can be nil and not accessible

### DIFF
--- a/dev/ha/config.go
+++ b/dev/ha/config.go
@@ -333,9 +333,11 @@ func (o *entry_v1) normalize() Config {
 	if o.StateSync != nil {
 		ans.Ha2StateSyncEnable = util.AsBool(o.StateSync.Enable)
 		ans.Ha2StateSyncTransport = o.StateSync.Transport
-		ans.Ha2StateSyncKeepAliveEnable = util.AsBool(o.StateSync.Ha2KeepAlive.Enable)
-		ans.Ha2StateSyncKeepAliveAction = o.StateSync.Ha2KeepAlive.Action
-		ans.Ha2StateSyncKeepAliveThreshold = o.StateSync.Ha2KeepAlive.Threshold
+		if o.StateSync.Ha2KeepAlive != nil {
+			ans.Ha2StateSyncKeepAliveEnable = util.AsBool(o.StateSync.Ha2KeepAlive.Enable)
+			ans.Ha2StateSyncKeepAliveAction = o.StateSync.Ha2KeepAlive.Action
+			ans.Ha2StateSyncKeepAliveThreshold = o.StateSync.Ha2KeepAlive.Threshold
+		}
 	}
 
 	if o.LinkMonitor != nil {


### PR DESCRIPTION
## Description

While working with the HA config, I found a condition when StateSync.Ha2KeepAlive  was `nil` so this code was raising `panic`

## Motivation and Context

Avoid panic under some config status.

## How Has This Been Tested?

Retrieving same config status via `Client.Device.HaConfig.Get()`

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
