### PR TITLE
fix: add `decryption` log forwarding type

### DIFF
--- a/objs/profile/logfwd/matchlist/const.go
+++ b/objs/profile/logfwd/matchlist/const.go
@@ -2,16 +2,18 @@ package matchlist
 
 // These are valid values for LogType.
 // The value "sctp" is valid for PAN-OS 8.1+.
+// The value "decryption" is valid for PAN-OS 10.0+.
 const (
-	LogTypeTraffic  = "traffic"
-	LogTypeThreat   = "threat"
-	LogTypeWildfire = "wildfire"
-	LogTypeUrl      = "url"
-	LogTypeData     = "data"
-	LogTypeGtp      = "gtp"
-	LogTypeTunnel   = "tunnel"
-	LogTypeAuth     = "auth"
-	LogTypeSctp     = "sctp"
+	LogTypeTraffic    = "traffic"
+	LogTypeThreat     = "threat"
+	LogTypeWildfire   = "wildfire"
+	LogTypeUrl        = "url"
+	LogTypeData       = "data"
+	LogTypeGtp        = "gtp"
+	LogTypeTunnel     = "tunnel"
+	LogTypeAuth       = "auth"
+	LogTypeSctp       = "sctp"
+	LogTypeDecryption = "decryption"
 )
 
 const (


### PR DESCRIPTION
For PAN-OS 10.0+

## Description

Add `decryption` log forwarding type

## Motivation and Context

I need it, and it's missing.

## How Has This Been Tested?

With a custom build of terraform-provider-panos

## Types of changes

- Bug fix

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
