### PR TITLE
Performance improvements - use running-config.xml

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/PaloAltoNetworks/pango/plugin"
 	"github.com/PaloAltoNetworks/pango/util"
 	"github.com/PaloAltoNetworks/pango/version"
+	"github.com/antchfx/xmlquery"
 )
 
 // These bit flags control what is logged by client connections.  Of the flags
@@ -116,6 +117,10 @@ type Client struct {
 	credsFile string
 	con       *http.Client
 	api_url   string
+
+	// XML document for client's running-config
+	UseRunningCfg bool
+	RunningCfgDoc *xmlquery.Node
 
 	// Variables for testing, response bytes, headers, and response index.
 	rp              []url.Values
@@ -1466,6 +1471,21 @@ func (c *Client) typeConfig(action string, data url.Values, element, extras, ans
 		c.MultiConfigure.Reqs = append(c.MultiConfigure.Reqs, r)
 		return nil, nil
 	}
+	if c.UseRunningCfg && (action == "show" || action == "get") {
+		buf := bytes.Buffer{}
+		for _, xpath := range data["xpath"] {
+			if list := xmlquery.Find(c.RunningCfgDoc, xpath); list != nil {
+				buf.Write([]byte("<response status='success'><result>"))
+				for _, listE := range list {
+					buf.Write([]byte(listE.OutputXML(true)))
+				}
+				buf.Write([]byte("</result></response>"))
+			} else {
+				return nil, PanosError{Msg: "No such node", Code: 0}
+			}
+		}
+		return buf.Bytes(), nil
+	}
 
 	data.Set("type", "config")
 	data.Set("action", action)
@@ -1928,6 +1948,22 @@ func (c *Client) logSend(data url.Values) {
 	if b.Len() > 0 {
 		log.Printf("%s", b.String())
 	}
+}
+
+func (c *Client) LoadRunningConfig() (err error) {
+	if !c.UseRunningCfg {
+		return fmt.Errorf("pango not initialized to use running config")
+	}
+	var runningCfgFile *os.File
+	runningCfgPath := "running-config.xml"
+
+	if runningCfgFile, err = os.Open(runningCfgPath); err != nil {
+		return
+	}
+	if c.RunningCfgDoc, err = xmlquery.Parse(runningCfgFile); err != nil {
+		return
+	}
+	return
 }
 
 /** Non-struct private functions **/

--- a/fw.go
+++ b/fw.go
@@ -64,6 +64,10 @@ func (c *Firewall) Initialize() error {
 			return e
 		} else if e = c.initSystemInfo(); e != nil {
 			return e
+		} else if c.UseRunningCfg {
+			if e = c.LoadRunningConfig(); e != nil {
+				return e
+			}
 		}
 		if c.Version.Gte(version.Number{9, 0, 0, ""}) {
 			c.initPlugins()

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/PaloAltoNetworks/pango
 
 go 1.12
+
+require github.com/antchfx/xmlquery v1.3.6


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Drag any screenshots here or delete this section -->
Get & Show APIs for all the namespaces use the PanOS XML APIs
to retrieve the configuration from the FW device. XML APIs are
pretty slow - their response time is between 300 and 500 ms.
As a result, for clients that request lots of configuration such
as OpenConfig plugin, the user experience is really bad - based
on the configuration, certain GNMI Get operations take up to
35mins.

XML APIs are unnecessary when the pango and the target device
are on the same host. In that case, the configuration can simply
be retrieved from the running-config.xml file. This commit
introduces that capability:

* Allow the client to control whether running-config.xml is
used or not.
* Introduce the API LoadRunningConfig which allows the client
to control when the running-config.xml is read. pango will
read it upon the call to Initialize.
* Get and Show use the xmlquery package to extract the
configuration from the running-config.xml.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
OpenConfig Plugin performance improvements - PLUG-8915.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested these changes using the OpenConfig plugin Get functionality. 

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality).