### PR TITLE
Fix typos of "" (e.g., `xml:"nssa-ext-range""`) in struct tags.

### DIFF
--- a/netw/routing/protocol/ospf/area/entry.go
+++ b/netw/routing/protocol/ospf/area/entry.go
@@ -196,11 +196,11 @@ type advertise struct {
 type nssa struct {
 	DefaultRoute  *defroute      `xml:"default-route"`
 	AcceptSummary string         `xml:"accept-summary"`
-	Ranges        *advrangeEntry `xml:"nssa-ext-range""`
+	Ranges        *advrangeEntry `xml:"nssa-ext-range"`
 }
 
 type advrangeEntry struct {
-	Entry []advrange `xml:"entry""`
+	Entry []advrange `xml:"entry"`
 }
 
 type advrange struct {

--- a/netw/routing/protocol/ospf/config.go
+++ b/netw/routing/protocol/ospf/config.go
@@ -147,7 +147,7 @@ type gracefulRestart struct {
 	GracePeriod            int    `xml:"grace-period,omitempty"`
 	HelperEnable           string `xml:"helper-enable"`
 	StrictLsaChecking      string `xml:"strict-LSA-checking"`
-	MaxNeighborRestartTime int    `xml:"max-neighbor-restart-time,omitempty""`
+	MaxNeighborRestartTime int    `xml:"max-neighbor-restart-time,omitempty"`
 }
 
 type globalBfd struct {


### PR DESCRIPTION
Fix issue #85 