### PR TITLE
fix(security.entry): hip-profiles removed from v10.1.5+

### DIFF
--- a/poli/security/entry.go
+++ b/poli/security/entry.go
@@ -709,3 +709,178 @@ func specify_v3(e Entry) interface{} {
 
 	return ans
 }
+
+// PAN-OS 10.1.5
+type container_v4 struct {
+	Answer []entry_v4 `xml:"entry"`
+}
+
+func (o *container_v4) Names() []string {
+	ans := make([]string, 0, len(o.Answer))
+	for i := range o.Answer {
+		ans = append(ans, o.Answer[i].Name)
+	}
+
+	return ans
+}
+
+func (o *container_v4) Normalize() []Entry {
+	arr := make([]Entry, 0, len(o.Answer))
+	for i := range o.Answer {
+		arr = append(arr, o.Answer[i].normalize())
+	}
+	return arr
+}
+
+func (o *entry_v4) normalize() Entry {
+	ans := Entry{
+		Name:                 o.Name,
+		Uuid:                 o.Uuid,
+		Type:                 o.Type,
+		Description:          o.Description,
+		Tags:                 util.MemToStr(o.Tags),
+		SourceZones:          util.MemToStr(o.SourceZones),
+		DestinationZones:     util.MemToStr(o.DestinationZones),
+		SourceAddresses:      util.MemToStr(o.SourceAddresses),
+		NegateSource:         util.AsBool(o.NegateSource),
+		SourceUsers:          util.MemToStr(o.SourceUsers),
+		DestinationAddresses: util.MemToStr(o.DestinationAddresses),
+		NegateDestination:    util.AsBool(o.NegateDestination),
+		Applications:         util.MemToStr(o.Applications),
+		Services:             util.MemToStr(o.Services),
+		Categories:           util.MemToStr(o.Categories),
+		Action:               o.Action,
+		LogSetting:           o.LogSetting,
+		LogStart:             util.AsBool(o.LogStart),
+		LogEnd:               util.AsBool(o.LogEnd),
+		Disabled:             util.AsBool(o.Disabled),
+		Schedule:             o.Schedule,
+		IcmpUnreachable:      util.AsBool(o.IcmpUnreachable),
+		GroupTag:             o.GroupTag,
+		SourceDevices:        util.MemToStr(o.SourceDevices),
+		DestinationDevices:   util.MemToStr(o.DestinationDevices),
+	}
+	if o.Options != nil {
+		ans.DisableServerResponseInspection = util.AsBool(o.Options.DisableServerResponseInspection)
+	}
+	if o.TargetInfo != nil {
+		ans.NegateTarget = util.AsBool(o.TargetInfo.NegateTarget)
+		ans.Targets = util.VsysEntToMap(o.TargetInfo.Targets)
+	}
+	if o.ProfileSettings != nil {
+		ans.Group = util.MemToOneStr(o.ProfileSettings.Group)
+		if o.ProfileSettings.Profiles != nil {
+			ans.Virus = util.MemToOneStr(o.ProfileSettings.Profiles.Virus)
+			ans.Spyware = util.MemToOneStr(o.ProfileSettings.Profiles.Spyware)
+			ans.Vulnerability = util.MemToOneStr(o.ProfileSettings.Profiles.Vulnerability)
+			ans.UrlFiltering = util.MemToOneStr(o.ProfileSettings.Profiles.UrlFiltering)
+			ans.FileBlocking = util.MemToOneStr(o.ProfileSettings.Profiles.FileBlocking)
+			ans.WildFireAnalysis = util.MemToOneStr(o.ProfileSettings.Profiles.WildFireAnalysis)
+			ans.DataFiltering = util.MemToOneStr(o.ProfileSettings.Profiles.DataFiltering)
+		}
+	}
+
+	return ans
+}
+
+type entry_v4 struct {
+	XMLName              xml.Name         `xml:"entry"`
+	Name                 string           `xml:"name,attr"`
+	Uuid                 string           `xml:"uuid,attr,omitempty"`
+	Type                 string           `xml:"rule-type,omitempty"`
+	Description          string           `xml:"description,omitempty"`
+	Tags                 *util.MemberType `xml:"tag"`
+	SourceZones          *util.MemberType `xml:"from"`
+	DestinationZones     *util.MemberType `xml:"to"`
+	SourceAddresses      *util.MemberType `xml:"source"`
+	NegateSource         string           `xml:"negate-source"`
+	SourceUsers          *util.MemberType `xml:"source-user"`
+	DestinationAddresses *util.MemberType `xml:"destination"`
+	NegateDestination    string           `xml:"negate-destination"`
+	Applications         *util.MemberType `xml:"application"`
+	Services             *util.MemberType `xml:"service"`
+	Categories           *util.MemberType `xml:"category"`
+	Action               string           `xml:"action"`
+	LogSetting           string           `xml:"log-setting,omitempty"`
+	LogStart             string           `xml:"log-start"`
+	LogEnd               string           `xml:"log-end"`
+	Disabled             string           `xml:"disabled"`
+	Schedule             string           `xml:"schedule,omitempty"`
+	IcmpUnreachable      string           `xml:"icmp-unreachable"`
+	Options              *secOptions      `xml:"option"`
+	TargetInfo           *targetInfo      `xml:"target"`
+	ProfileSettings      *profileSettings `xml:"profile-setting"`
+	GroupTag             string           `xml:"group-tag,omitempty"`
+	SourceDevices        *util.MemberType `xml:"source-hip"`
+	DestinationDevices   *util.MemberType `xml:"destination-hip"`
+}
+
+func (e *entry_v4) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type local entry_v4
+	ans := local{
+		LogEnd: util.YesNo(true),
+	}
+	if err := d.DecodeElement(&ans, &start); err != nil {
+		return err
+	}
+	*e = entry_v4(ans)
+	return nil
+}
+
+func specify_v4(e Entry) interface{} {
+	ans := entry_v4{
+		Name:                 e.Name,
+		Uuid:                 e.Uuid,
+		Type:                 e.Type,
+		Description:          e.Description,
+		Tags:                 util.StrToMem(e.Tags),
+		SourceZones:          util.StrToMem(e.SourceZones),
+		DestinationZones:     util.StrToMem(e.DestinationZones),
+		SourceAddresses:      util.StrToMem(e.SourceAddresses),
+		NegateSource:         util.YesNo(e.NegateSource),
+		SourceUsers:          util.StrToMem(e.SourceUsers),
+		DestinationAddresses: util.StrToMem(e.DestinationAddresses),
+		NegateDestination:    util.YesNo(e.NegateDestination),
+		Applications:         util.StrToMem(e.Applications),
+		Services:             util.StrToMem(e.Services),
+		Categories:           util.StrToMem(e.Categories),
+		Action:               e.Action,
+		LogSetting:           e.LogSetting,
+		LogStart:             util.YesNo(e.LogStart),
+		LogEnd:               util.YesNo(e.LogEnd),
+		Disabled:             util.YesNo(e.Disabled),
+		Schedule:             e.Schedule,
+		IcmpUnreachable:      util.YesNo(e.IcmpUnreachable),
+		Options:              &secOptions{util.YesNo(e.DisableServerResponseInspection)},
+		GroupTag:             e.GroupTag,
+		SourceDevices:        util.StrToMem(e.SourceDevices),
+		DestinationDevices:   util.StrToMem(e.DestinationDevices),
+	}
+	if e.Targets != nil || e.NegateTarget {
+		nfo := &targetInfo{
+			Targets:      util.MapToVsysEnt(e.Targets),
+			NegateTarget: util.YesNo(e.NegateTarget),
+		}
+		ans.TargetInfo = nfo
+	}
+	gs := e.Virus != "" || e.Spyware != "" || e.Vulnerability != "" || e.UrlFiltering != "" || e.FileBlocking != "" || e.WildFireAnalysis != "" || e.DataFiltering != ""
+	if e.Group != "" || gs {
+		ps := &profileSettings{
+			Group: util.OneStrToMem(e.Group),
+		}
+		if gs {
+			ps.Profiles = &profileSettingsProfile{
+				util.OneStrToMem(e.Virus),
+				util.OneStrToMem(e.Spyware),
+				util.OneStrToMem(e.Vulnerability),
+				util.OneStrToMem(e.UrlFiltering),
+				util.OneStrToMem(e.FileBlocking),
+				util.OneStrToMem(e.WildFireAnalysis),
+				util.OneStrToMem(e.DataFiltering),
+			}
+		}
+		ans.ProfileSettings = ps
+	}
+
+	return ans
+}

--- a/poli/security/funcs.go
+++ b/poli/security/funcs.go
@@ -9,7 +9,9 @@ import (
 )
 
 func versioning(v version.Number) (normalizer, func(Entry) interface{}) {
-	if v.Gte(version.Number{10, 0, 0, ""}) {
+	if v.Gte(version.Number{10, 1, 5, ""}) {
+		return &container_v4{}, specify_v4
+	} else if v.Gte(version.Number{10, 0, 0, ""}) {
 		return &container_v3{}, specify_v3
 	} else if v.Gte(version.Number{9, 0, 0, ""}) {
 		return &container_v2{}, specify_v2


### PR DESCRIPTION
## Description

This pull request removes the hip-profiles field for Panos version 10.1.5+

## Motivation and Context

In version 10.1.5 of Panos, hip profiles are no longer supported in security policies. 

## How Has This Been Tested?

This code has been tested to create rules on a PA-3220 in Panos Version 10.1.5-h1

## Types of changes

- Bug fix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
