### PR TITLE
Panorama: ConfigureRules should not suppress err while deleting rules

### DIFF
--- a/poli/security/pano.go
+++ b/poli/security/pano.go
@@ -151,7 +151,9 @@ func (c *Panorama) ConfigureRules(dg, base string, rules []Entry, auditComments 
 		}
 
 		if len(rmList) != 0 {
-			_ = c.Delete(dg, base, rmList...)
+			if err := c.Delete(dg, base, rmList...); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

We faced a scenario where Panos Terraform provider gives a false positive result while performing changes (deletion of rules) in a `panos_panorama_security_rule_group`.

```sh
# From the TF_LOG=debug
curl -k 'https://<PANORAMA SERVER>/api?action=delete&key=<PANORAMA KEY>&type=config&xpath=%2Fconfig%2Fdevices%2Fentry%5B%40name%3D%27localhost.localdomain%27%5D%2Fdevice-group%2Fentry%5B%40name%3D%27<DEVICE GROUP NAME>%27%5D%2Fpre-rulebase%2Fsecurity%2Frules%2Fentry%5B%40name%3D%27<1st SECURITY POLICY NAME>%27+or+%40name%3D%27<2nd SECURITY POLICY NAME>%27%5D'
<response status="error" code="13"><msg><line>The request could not be handled</line></msg></response>
```

## Motivation and Context

https://github.com/PaloAltoNetworks/pango/blob/master/poli/security/pano.go#L154


## How Has This Been Tested?

Built panos Terraform provider with these changes and tested them across various Panorama instances and device groups.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
