### PR TITLE
Fix Incorrect Certificate Reference on Panorama panos_certificate_import

### DIFF
--- a/dev/certificate/pano.go
+++ b/dev/certificate/pano.go
@@ -111,7 +111,7 @@ func (c *Panorama) ImportPem(tmpl, vsys string, timeout time.Duration, cert Pem)
 
 	ex.Set("passphrase", cert.Passphrase)
 
-	_, err = c.ns.Client.Import("certificate", cert.PrivateKey, cert.PrivateKeyFilename, "file", timeout, ex, nil)
+	_, err = c.ns.Client.Import("private-key", cert.PrivateKey, cert.PrivateKeyFilename, "file", timeout, ex, nil)
 
 	return err
 }

--- a/dev/certificate/pano.go
+++ b/dev/certificate/pano.go
@@ -118,6 +118,8 @@ func (c *Panorama) ImportPem(tmpl, vsys string, timeout time.Duration, cert Pem)
 
 // ImportPkcs12 imports a PKCS12 certificate.
 func (c *Panorama) ImportPkcs12(tmpl, vsys string, timeout time.Duration, cert Pkcs12) error {
+	var err error
+
 	c.ns.Client.LogImport("(import) pkcs12 %s: %s", singular, cert.Name)
 
 	ex := url.Values{}
@@ -133,7 +135,7 @@ func (c *Panorama) ImportPkcs12(tmpl, vsys string, timeout time.Duration, cert P
 		ex.Set("target-tpl-vsys", vsys)
 	}
 
-	_, err := c.ns.Client.Import("certificate", cert.Certificate, cert.CertificateFilename, "file", timeout, ex, nil)
+	_, err = c.ns.Client.Import("certificate", cert.Certificate, cert.CertificateFilename, "file", timeout, ex, nil)
 
 	return err
 }


### PR DESCRIPTION
## Description

Terraform panos_certificate_import works on firewalls but not on Panorama, while the certificate imports fine via the Panorama GUI.

## Motivation and Context

Fixing the bug outlined here:
https://github.com/PaloAltoNetworks/pango/issues/95

## How Has This Been Tested?

Made change locally, recompiled terraform-provider-panos, pointed my local TF to use the DEV provider, pushed a test PEM certificate to Panorama.  Works, certificate is valid in Panorama and no longer throws an error.  

This is my first public bug fix, first time working in GO and first time with a custom terraform provider.  Assume I know nothing and this change could break something.

There may be a lingering bug with PKCS12 certificates, I only tested PEM.  I will test PKCS12 next.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
