### PR TITLE
Add support for "device-priority" type for templates variables

### DIFF
--- a/pnrm/template/variable/const.go
+++ b/pnrm/template/variable/const.go
@@ -2,11 +2,12 @@ package variable
 
 // These are the constants for the Type field.
 const (
-	TypeIpNetmask = "ip-netmask"
-	TypeIpRange   = "ip-range"
-	TypeFqdn      = "fqdn"
-	TypeGroupId   = "group-id"
-	TypeInterface = "interface"
+	TypeIpNetmask      = "ip-netmask"
+	TypeIpRange        = "ip-range"
+	TypeFqdn           = "fqdn"
+	TypeGroupId        = "group-id"
+	TypeInterface      = "interface"
+	TypeDevicePriority = "device-priority"
 )
 
 const (

--- a/pnrm/template/variable/entry.go
+++ b/pnrm/template/variable/entry.go
@@ -77,19 +77,23 @@ func (o *entry_v1) normalize() Entry {
 	} else if o.Interface != "" {
 		ans.Type = TypeInterface
 		ans.Value = o.Interface
+	} else if o.DevicePriority != "" {
+		ans.Type = TypeDevicePriority
+		ans.Value = o.DevicePriority
 	}
 
 	return ans
 }
 
 type entry_v1 struct {
-	XMLName   xml.Name `xml:"entry"`
-	Name      string   `xml:"name,attr"`
-	IpNetmask string   `xml:"type>ip-netmask,omitempty"`
-	IpRange   string   `xml:"type>ip-range,omitempty"`
-	Fqdn      string   `xml:"type>fqdn,omitempty"`
-	GroupId   string   `xml:"type>group-id,omitempty"`
-	Interface string   `xml:"type>interface,omitempty"`
+	XMLName        xml.Name `xml:"entry"`
+	Name           string   `xml:"name,attr"`
+	IpNetmask      string   `xml:"type>ip-netmask,omitempty"`
+	IpRange        string   `xml:"type>ip-range,omitempty"`
+	Fqdn           string   `xml:"type>fqdn,omitempty"`
+	GroupId        string   `xml:"type>group-id,omitempty"`
+	Interface      string   `xml:"type>interface,omitempty"`
+	DevicePriority string   `xml:"type>device-priority,omitempty"`
 }
 
 func specify_v1(e Entry) interface{} {
@@ -108,6 +112,8 @@ func specify_v1(e Entry) interface{} {
 		ans.GroupId = e.Value
 	case TypeInterface:
 		ans.Interface = e.Value
+	case TypeDevicePriority:
+		ans.DevicePriority = e.Value
 	}
 
 	return ans

--- a/pnrm/template/variable/pano_test.go
+++ b/pnrm/template/variable/pano_test.go
@@ -39,7 +39,7 @@ func TestNormalization(t *testing.T) {
 		}},
 		{"device priority test", Entry{
 			Name:  "$prio1",
-			Type:  TypeInterface,
+			Type:  TypeDevicePriority,
 			Value: "150",
 		}},
 	}

--- a/pnrm/template/variable/pano_test.go
+++ b/pnrm/template/variable/pano_test.go
@@ -37,6 +37,11 @@ func TestNormalization(t *testing.T) {
 			Type:  TypeInterface,
 			Value: "ethernet1/1",
 		}},
+		{"device priority test", Entry{
+			Name:  "$prio1",
+			Type:  TypeInterface,
+			Value: "150",
+		}},
 	}
 
 	mc := &testdata.MockClient{}


### PR DESCRIPTION
## Description

Add support for "device-priority" type for templates variables

## Motivation and Context

Device priority type was missing from pango for template variables

## How Has This Been Tested?

Tested with development panorama instance :

2023/03/28 14:59:40 XXX: Retrieving API key
2023/03/28 14:59:42 (op) show system info
2023/03/28 14:59:43 (op) getting plugin info
2023/03/28 14:59:43 Initialize ok
2023/03/28 14:59:43 (edit) template variable: $prio1
2023/03/28 14:59:43 Successfully created variable : {$prio1 device-priority 150}

## Screenshots (if appropriate)

![Screenshot 2023-03-28 at 15 03 24](https://user-images.githubusercontent.com/60673868/228245144-f4f012ec-4c4a-48f1-864c-1b4c8bf50d8b.png)


## Types of changes

- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
