### PR TITLE
Add feature support for Panorama

### DIFF
--- a/dev/ha/funcs.go
+++ b/dev/ha/funcs.go
@@ -40,7 +40,7 @@ func FirewallNamespace(client util.XapiClient) *Firewall {
 }
 
 // PanoramaNamespace returns an initialized namespace.
-/*func PanoramaNamespace(client util.XapiClient) *Panorama {
+func PanoramaNamespace(client util.XapiClient) *Panorama {
 	return &Panorama{
 		ns: &namespace.Standard{
 			Common: namespace.Common{
@@ -49,4 +49,4 @@ func FirewallNamespace(client util.XapiClient) *Firewall {
 			},
 		},
 	}
-}*/
+}

--- a/dev/ha/monitor/link/funcs.go
+++ b/dev/ha/monitor/link/funcs.go
@@ -75,7 +75,7 @@ func FirewallNamespace(client util.XapiClient) *Firewall {
 }
 
 // PanoramaNamespace returns an initialized namespace.
-/*func PanoramaNamespace(client util.XapiClient) *Panorama {
+func PanoramaNamespace(client util.XapiClient) *Panorama {
 	return &Panorama{
 		ns: &namespace.Standard{
 			Common: namespace.Common{
@@ -85,4 +85,4 @@ func FirewallNamespace(client util.XapiClient) *Firewall {
 			},
 		},
 	}
-}*/
+}

--- a/dev/ha/monitor/link/pano.go
+++ b/dev/ha/monitor/link/pano.go
@@ -1,0 +1,104 @@
+package link
+
+import (
+	"fmt"
+
+	"github.com/PaloAltoNetworks/pango/namespace"
+	"github.com/PaloAltoNetworks/pango/util"
+)
+
+// Panorama is the client.Device.HaLinkMonitorGroup namespace.
+type Panorama struct {
+	ns *namespace.Standard
+}
+
+// GetList performs GET to retrieve a list of all objects.
+func (c *Panorama) GetList(tmpl, ts, vsys string) ([]string, error) {
+	ans := c.container()
+	return c.ns.Listing(util.Get, c.pather(tmpl, ts, vsys), ans)
+}
+
+// ShowList performs SHOW to retrieve a list of all objects.
+func (c *Panorama) ShowList(tmpl, ts, vsys string) ([]string, error) {
+	ans := c.container()
+	return c.ns.Listing(util.Show, c.pather(tmpl, ts, vsys), ans)
+}
+
+// Get performs GET to retrieve information for the given object.
+func (c *Panorama) Get(tmpl, ts, vsys string, name string) (Entry, error) {
+	ans := c.container()
+	err := c.ns.Object(util.Get, c.pather(tmpl, ts, vsys), name, ans)
+	return first(ans, err)
+}
+
+// Show performs SHOW to retrieve information for the given object.
+func (c *Panorama) Show(tmpl, ts, vsys string, name string) (Entry, error) {
+	ans := c.container()
+	err := c.ns.Object(util.Show, c.pather(tmpl, ts, vsys), name, ans)
+	return first(ans, err)
+}
+
+// GetAll performs GET to retrieve all objects configured.
+func (c *Panorama) GetAll(tmpl, ts, vsys string) ([]Entry, error) {
+	ans := c.container()
+	err := c.ns.Objects(util.Get, c.pather(tmpl, ts, vsys), ans)
+	return all(ans, err)
+}
+
+// ShowAll performs SHOW to retrieve information for all objects.
+func (c *Panorama) ShowAll(tmpl, ts, vsys string) ([]Entry, error) {
+	ans := c.container()
+	err := c.ns.Objects(util.Show, c.pather(tmpl, ts, vsys), ans)
+	return all(ans, err)
+}
+
+// Set performs SET to configure the specified objects.
+func (c *Panorama) Set(tmpl, ts, vsys string, e ...Entry) error {
+	return c.ns.Set(c.pather(tmpl, ts, vsys), specifier(e...))
+}
+
+// Edit performs EDIT to configure the specified object.
+func (c *Panorama) Edit(tmpl, ts, vsys string, e Entry) error {
+	return c.ns.Edit(c.pather(tmpl, ts, vsys), e)
+}
+
+// Delete performs DELETE to remove the specified objects.
+//
+// Objects can be either a string or an Entry object.
+func (c *Panorama) Delete(tmpl, ts, vsys string, e ...interface{}) error {
+	names, nErr := toNames(e)
+	return c.ns.Delete(c.pather(tmpl, ts, vsys), names, nErr)
+}
+
+func (c *Panorama) pather(tmpl, ts, vsys string) namespace.Pather {
+	return func(v []string) ([]string, error) {
+		return c.xpath(tmpl, ts, vsys, v)
+	}
+}
+
+func (c *Panorama) xpath(tmpl, ts, vsys string, vals []string) ([]string, error) {
+	if tmpl == "" && ts == "" {
+		return nil, fmt.Errorf("tmpl or ts must be specified")
+	}
+
+	ans := make([]string, 0, 12)
+	ans = append(ans, util.TemplateXpathPrefix(tmpl, ts)...)
+	ans = append(ans,
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"deviceconfig",
+		"high-availability",
+		"group",
+		"monitoring",
+		"link-monitoring",
+		"link-group",
+		util.AsEntryXpath(vals),
+	)
+
+	return ans, nil
+}
+
+func (c *Panorama) container() normalizer {
+	return container(c.ns.Client.Versioning())
+}

--- a/dev/ha/monitor/link/pano_test.go
+++ b/dev/ha/monitor/link/pano_test.go
@@ -1,0 +1,36 @@
+package link
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/PaloAltoNetworks/pango/testdata"
+)
+
+func TestPanoNormalization(t *testing.T) {
+	testCases := getTests()
+
+	mc := &testdata.MockClient{}
+	ns := PanoramaNamespace(mc)
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			mc.Version = tc.version
+			mc.Reset()
+			mc.AddResp("")
+			err := ns.Set("my template", "", "", tc.conf)
+			if err != nil {
+				t.Errorf("Error in set: %s", err)
+			} else {
+				mc.AddResp(mc.Elm)
+				r, err := ns.Get("my template", "", "", tc.conf.Name)
+				if err != nil {
+					t.Errorf("Error in get: %s", err)
+				}
+				if !reflect.DeepEqual(tc.conf, r) {
+					t.Errorf("%#v != %#v", tc.conf, r)
+				}
+			}
+		})
+	}
+}

--- a/dev/ha/monitor/path/funcs.go
+++ b/dev/ha/monitor/path/funcs.go
@@ -75,7 +75,7 @@ func FirewallNamespace(client util.XapiClient) *Firewall {
 }
 
 // PanoramaNamespace returns an initialized namespace.
-/*func PanoramaNamespace(client util.XapiClient) *Panorama {
+func PanoramaNamespace(client util.XapiClient) *Panorama {
 	return &Panorama{
 		ns: &namespace.Standard{
 			Common: namespace.Common{
@@ -85,4 +85,4 @@ func FirewallNamespace(client util.XapiClient) *Firewall {
 			},
 		},
 	}
-}*/
+}

--- a/dev/ha/monitor/path/pano.go
+++ b/dev/ha/monitor/path/pano.go
@@ -1,0 +1,113 @@
+package path
+
+import (
+	"fmt"
+
+	"github.com/PaloAltoNetworks/pango/namespace"
+	"github.com/PaloAltoNetworks/pango/util"
+)
+
+// Panorama is the client.Device.HaPathMonitorGroup namespace.
+type Panorama struct {
+	ns *namespace.Standard
+}
+
+// GetList performs GET to retrieve a list of all objects.
+func (c *Panorama) GetList(tmpl, ts, vsys, gType string) ([]string, error) {
+	ans := c.container()
+	return c.ns.Listing(util.Get, c.pather(tmpl, ts, vsys, gType), ans)
+}
+
+// ShowList performs SHOW to retrieve a list of all objects.
+func (c *Panorama) ShowList(tmpl, ts, vsys, gType string) ([]string, error) {
+	ans := c.container()
+	return c.ns.Listing(util.Show, c.pather(tmpl, ts, vsys, gType), ans)
+}
+
+// Get performs GET to retrieve information for the given object.
+func (c *Panorama) Get(tmpl, ts, vsys, gType, name string) (Entry, error) {
+	ans := c.container()
+	err := c.ns.Object(util.Get, c.pather(tmpl, ts, vsys, gType), name, ans)
+	return first(ans, err)
+}
+
+// Show performs SHOW to retrieve information for the given object.
+func (c *Panorama) Show(tmpl, ts, vsys, gType, name string) (Entry, error) {
+	ans := c.container()
+	err := c.ns.Object(util.Show, c.pather(tmpl, ts, vsys, gType), name, ans)
+	return first(ans, err)
+}
+
+// GetAll performs GET to retrieve all objects configured.
+func (c *Panorama) GetAll(tmpl, ts, vsys, gType string) ([]Entry, error) {
+	ans := c.container()
+	err := c.ns.Objects(util.Get, c.pather(tmpl, ts, vsys, gType), ans)
+	return all(ans, err)
+}
+
+// ShowAll performs SHOW to retrieve information for all objects.
+func (c *Panorama) ShowAll(tmpl, ts, vsys, gType string) ([]Entry, error) {
+	ans := c.container()
+	err := c.ns.Objects(util.Show, c.pather(tmpl, ts, vsys, gType), ans)
+	return all(ans, err)
+}
+
+// Set performs SET to configure the specified objects.
+func (c *Panorama) Set(tmpl, ts, vsys, gType string, e ...Entry) error {
+	return c.ns.Set(c.pather(tmpl, ts, vsys, gType), specifier(e...))
+}
+
+// Edit performs EDIT to configure the specified object.
+func (c *Panorama) Edit(tmpl, ts, vsys, gType string, e Entry) error {
+	return c.ns.Edit(c.pather(tmpl, ts, vsys, gType), e)
+}
+
+// Delete performs DELETE to remove the specified objects.
+//
+// Objects can be either a string or an Entry object.
+func (c *Panorama) Delete(tmpl, ts, vsys, gType string, e ...interface{}) error {
+	names, nErr := toNames(e)
+	return c.ns.Delete(c.pather(tmpl, ts, vsys, gType), names, nErr)
+}
+
+func (c *Panorama) pather(tmpl, ts, vsys, gType string) namespace.Pather {
+	return func(v []string) ([]string, error) {
+		return c.xpath(tmpl, ts, vsys, gType, v)
+	}
+}
+
+func (c *Panorama) xpath(tmpl, ts, vsys string, gType string, vals []string) ([]string, error) {
+	if tmpl == "" && ts == "" {
+		return nil, fmt.Errorf("tmpl or ts must be specified")
+	}
+
+	switch gType {
+	case "":
+		return nil, fmt.Errorf("gType must be specified")
+	case VirtualWire, Vlan, VirtualRouter, LogicalRouter:
+	default:
+		return nil, fmt.Errorf("unknown gType value: %s", gType)
+	}
+
+	ans := make([]string, 0, 12)
+	ans = append(ans, util.TemplateXpathPrefix(tmpl, ts)...)
+	ans = append(ans,
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"deviceconfig",
+		"high-availability",
+		"group",
+		"monitoring",
+		"path-monitoring",
+		"path-group",
+		gType,
+		util.AsEntryXpath(vals),
+	)
+
+	return ans, nil
+}
+
+func (c *Panorama) container() normalizer {
+	return container(c.ns.Client.Versioning())
+}

--- a/dev/ha/monitor/path/pano_test.go
+++ b/dev/ha/monitor/path/pano_test.go
@@ -1,0 +1,36 @@
+package path
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/PaloAltoNetworks/pango/testdata"
+)
+
+func TestPanoNormalization(t *testing.T) {
+	testCases := getTests()
+
+	mc := &testdata.MockClient{}
+	ns := PanoramaNamespace(mc)
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			mc.Version = tc.version
+			mc.Reset()
+			mc.AddResp("")
+			err := ns.Set("my template", "", "", tc.gType, tc.conf)
+			if err != nil {
+				t.Errorf("Error in set: %s", err)
+			} else {
+				mc.AddResp(mc.Elm)
+				r, err := ns.Get("my template", "", "", tc.gType, tc.conf.Name)
+				if err != nil {
+					t.Errorf("Error in get: %s", err)
+				}
+				if !reflect.DeepEqual(tc.conf, r) {
+					t.Errorf("%#v != %#v", tc.conf, r)
+				}
+			}
+		})
+	}
+}

--- a/dev/ha/pano.go
+++ b/dev/ha/pano.go
@@ -1,0 +1,65 @@
+package ha
+
+import (
+	"fmt"
+
+	"github.com/PaloAltoNetworks/pango/namespace"
+	"github.com/PaloAltoNetworks/pango/util"
+)
+
+// Panorama is the client.Device.GeneralSettings namespace.
+type Panorama struct {
+	ns *namespace.Standard
+}
+
+// Get performs GET to retrieve the device's general settings.
+func (c *Panorama) Get(tmpl, ts, vsys string) (Config, error) {
+	ans := c.container()
+	err := c.ns.Object(util.Get, c.pather(tmpl, ts, vsys), "", ans)
+	return first(ans, err)
+}
+
+// Show performs SHOW to retrieve the device's general settings.
+func (c *Panorama) Show(tmpl, ts, vsys string) (Config, error) {
+	ans := c.container()
+	err := c.ns.Object(util.Show, c.pather(tmpl, ts, vsys), "", ans)
+	return first(ans, err)
+}
+
+// Set performs SET to configure the specified objects.
+func (c *Panorama) Set(tmpl, ts, vsys string, e Config) error {
+	return c.ns.Set(c.pather(tmpl, ts, vsys), specifier(e))
+}
+
+// Edit performs EDIT to update the device's general settings.
+func (c *Panorama) Edit(tmpl, ts, vsys string, e Config) error {
+	return c.ns.Edit(c.pather(tmpl, ts, vsys), e)
+}
+
+func (c *Panorama) pather(tmpl, ts, vsys string) namespace.Pather {
+	return func(v []string) ([]string, error) {
+		return c.xpath(tmpl, ts, vsys)
+	}
+}
+
+func (c *Panorama) xpath(tmpl, ts, vsys string) ([]string, error) {
+	if tmpl == "" && ts == "" {
+		return nil, fmt.Errorf("tmpl or ts must be specified")
+	}
+
+	ans := make([]string, 0, 12)
+	ans = append(ans, util.TemplateXpathPrefix(tmpl, ts)...)
+	ans = append(ans,
+		"config",
+		"devices",
+		util.AsEntryXpath([]string{"localhost.localdomain"}),
+		"deviceconfig",
+		"high-availability",
+	)
+
+	return ans, nil
+}
+
+func (c *Panorama) container() normalizer {
+	return container(c.ns.Client.Versioning())
+}

--- a/dev/ha/pano_test.go
+++ b/dev/ha/pano_test.go
@@ -1,0 +1,134 @@
+package ha
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/PaloAltoNetworks/pango/testdata"
+	"github.com/PaloAltoNetworks/pango/version"
+)
+
+func TestPanoNormalization(t *testing.T) {
+	testCases := getTests()
+
+	mc := &testdata.MockClient{}
+	ns := PanoramaNamespace(mc)
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			mc.Version = tc.version
+			mc.Reset()
+			mc.AddResp("")
+			err := ns.Set("my template", "", "", tc.conf)
+			if err != nil {
+				t.Errorf("Error in set: %s", err)
+			} else {
+				mc.AddResp(mc.Elm)
+				r, err := ns.Get("my template", "", "")
+				if err != nil {
+					t.Errorf("Error in get: %s", err)
+				}
+				if !reflect.DeepEqual(tc.conf, r) {
+					t.Errorf("%#v != %#v", tc.conf, r)
+				}
+			}
+		})
+	}
+}
+
+func TestPanoHa2StateSyncEnableIsTrueWithNoStateSyncConfig(t *testing.T) {
+	mc := &testdata.MockClient{
+		Version: version.Number{6, 1, 0, ""},
+	}
+	ns := FirewallNamespace(mc)
+	mc.AddResp(`
+<high-availability>
+    <enabled>yes</enabled>
+    <group>
+        <group-id>2</group-id>
+        <description>My description</description>
+        <peer-ip>127.0.0.1</peer-ip>
+        <configuration-synchronization>
+            <enabled>yes</enabled>
+        </configuration-synchronization>
+    </group>
+</high-availability>
+`)
+	ans, err := ns.Get()
+	if err != nil {
+		t.Errorf("Error in get: %s", err)
+	}
+	if ans.GroupId != 2 {
+		t.Errorf("GroupId is %d, not 2", ans.GroupId)
+	}
+	if !ans.Ha2StateSyncEnable {
+		t.Errorf("Ha2StateSyncEnable is incorrectly set to %t", ans.Ha2StateSyncEnable)
+	}
+}
+
+func TestPanoHa2StateSyncEnableIsTrueWithStateSyncConfig(t *testing.T) {
+	mc := &testdata.MockClient{
+		Version: version.Number{6, 1, 0, ""},
+	}
+	ns := FirewallNamespace(mc)
+	mc.AddResp(`
+<high-availability>
+    <enabled>yes</enabled>
+    <group>
+        <group-id>2</group-id>
+        <description>My description</description>
+        <peer-ip>127.0.0.1</peer-ip>
+        <configuration-synchronization>
+            <enabled>yes</enabled>
+        </configuration-synchronization>
+        <state-synchronization>
+            <transport>mytransport</transport>
+        </state-synchronization>
+    </group>
+</high-availability>
+`)
+	ans, err := ns.Get()
+	if err != nil {
+		t.Errorf("Error in get: %s", err)
+	}
+	if ans.GroupId != 2 {
+		t.Errorf("GroupId is %d, not 2", ans.GroupId)
+	}
+	if !ans.Ha2StateSyncEnable {
+		t.Errorf("Ha2StateSyncEnable is incorrectly set to %t", ans.Ha2StateSyncEnable)
+	}
+}
+
+func TestPanoHa2StateSyncEnableCanBeFalse(t *testing.T) {
+	mc := &testdata.MockClient{
+		Version: version.Number{6, 1, 0, ""},
+	}
+	ns := FirewallNamespace(mc)
+	mc.AddResp(`
+<high-availability>
+    <enabled>yes</enabled>
+    <group>
+        <group-id>2</group-id>
+        <description>My description</description>
+        <peer-ip>127.0.0.1</peer-ip>
+        <configuration-synchronization>
+            <enabled>yes</enabled>
+        </configuration-synchronization>
+        <state-synchronization>
+            <enabled>no</enabled>
+            <transport>mytransport</transport>
+        </state-synchronization>
+    </group>
+</high-availability>
+`)
+	ans, err := ns.Get()
+	if err != nil {
+		t.Errorf("Error in get: %s", err)
+	}
+	if ans.GroupId != 2 {
+		t.Errorf("GroupId is %d, not 2", ans.GroupId)
+	}
+	if ans.Ha2StateSyncEnable {
+		t.Errorf("Ha2StateSyncEnable is incorrectly set to %t", ans.Ha2StateSyncEnable)
+	}
+}

--- a/dev/pano.go
+++ b/dev/pano.go
@@ -4,6 +4,9 @@ import (
 	"github.com/PaloAltoNetworks/pango/util"
 
 	cert "github.com/PaloAltoNetworks/pango/dev/certificate"
+	"github.com/PaloAltoNetworks/pango/dev/ha"
+	halink "github.com/PaloAltoNetworks/pango/dev/ha/monitor/link"
+	hapath "github.com/PaloAltoNetworks/pango/dev/ha/monitor/path"
 	"github.com/PaloAltoNetworks/pango/dev/localuserdb/group"
 	"github.com/PaloAltoNetworks/pango/dev/localuserdb/user"
 	"github.com/PaloAltoNetworks/pango/dev/profile/authentication"
@@ -28,6 +31,9 @@ type Panorama struct {
 	Certificate           *cert.Panorama
 	CertificateProfile    *certificate.Panorama
 	EmailServerProfile    *email.Panorama
+	HaConfig              *ha.Panorama
+	HaLinkMonitorGroup    *halink.Panorama
+	HaPathMonitorGroup    *hapath.Panorama
 	HttpServerProfile     *http.Panorama
 	KerberosProfile       *kerberos.Panorama
 	LdapProfile           *ldap.Panorama
@@ -50,6 +56,9 @@ func PanoramaNamespace(x util.XapiClient) *Panorama {
 		Certificate:           cert.PanoramaNamespace(x),
 		CertificateProfile:    certificate.PanoramaNamespace(x),
 		EmailServerProfile:    email.PanoramaNamespace(x),
+		HaConfig:              ha.PanoramaNamespace(x),
+		HaLinkMonitorGroup:    halink.PanoramaNamespace(x),
+		HaPathMonitorGroup:    hapath.PanoramaNamespace(x),
 		HttpServerProfile:     http.PanoramaNamespace(x),
 		KerberosProfile:       kerberos.PanoramaNamespace(x),
 		LdapProfile:           ldap.PanoramaNamespace(x),


### PR DESCRIPTION
## Description

Added : 
- Device / General Settings
- Device / High Availability
- Device / High Availability / Link Monitoring
- Device / High Availability / Path Monitoring
- 
## Motivation and Context

Some features like the ones mentioned above are missing from Panorama connector. Those would need to be added in the terraform provider

## How Has This Been Tested?

Added tests from go test for all 4 features, Tested on a development Panorama also.

## Screenshots (if appropriate)

## Types of changes

- New feature (non-breaking change which adds functionality)

Note: Hostname attribute in the General Settings has been moved to "omitempty" in order to be able to have generic templates that do not override any more specific template or any locally configured value.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
