### PR TITLE
DGP-583: Add zone_protection and decryption profile

### DIFF
--- a/errors/panos.go
+++ b/errors/panos.go
@@ -81,7 +81,22 @@ type errorCheckMsg struct {
 }
 
 type errLine struct {
-	Text string `xml:",cdata"`
+	Text  string    `xml:",cdata"`
+	Lines []errLine `xml:"line"`
+}
+
+func (e errLine) message() string {
+	if e.Text != "" {
+		return strings.TrimSpace(e.Text)
+	}
+	var b strings.Builder
+	for i, l := range e.Lines {
+		if i != 0 {
+			b.WriteString(" | ")
+		}
+		b.WriteString(l.message())
+	}
+	return b.String()
 }
 
 func (e *errorCheck) Failed() bool {
@@ -102,7 +117,7 @@ func (e *errorCheck) Message() string {
 				if i != 0 {
 					b.WriteString(" | ")
 				}
-				b.WriteString(strings.TrimSpace(e.Msg.Line[i].Text))
+				b.WriteString(e.Msg.Line[i].message())
 			}
 			return b.String()
 		}

--- a/errors/panos_test.go
+++ b/errors/panos_test.go
@@ -71,3 +71,57 @@ func TestFailedExportErrorMessage(t *testing.T) {
 		}
 	}
 }
+
+func TestDoubleNestedLineErrorMessage(t *testing.T) {
+	data := `<response status="error" code="12"><msg><line><line><![CDATA[ profiles -> zone-protection-profile -> entry -> tcp-syn-with-data unexpected here]]></line><line><![CDATA[ profiles -> zone-protection-profile is invalid]]></line></line></msg></response>`
+
+	err := Parse([]byte(data))
+	if err == nil {
+		t.Errorf("Error is nil")
+		return
+	}
+	e2, ok := err.(Panos)
+	if !ok {
+		t.Errorf("Not a panos error")
+		return
+	}
+	if !strings.Contains(e2.Msg, "unexpected here") {
+		t.Errorf("Expected 'unexpected here' in message, got: %s", e2.Msg)
+	}
+	if !strings.Contains(e2.Msg, "is invalid") {
+		t.Errorf("Expected 'is invalid' in message, got: %s", e2.Msg)
+	}
+	if !strings.Contains(e2.Msg, " | ") {
+		t.Errorf("Expected lines to be joined with ' | ', got: %s", e2.Msg)
+	}
+}
+
+func TestSingleNestedLineErrorMessageUnchanged(t *testing.T) {
+	// Flat <line> with CDATA — existing behaviour must be preserved.
+	expected := "No such node"
+	data := `<response status="error"><msg><line>No such node</line></msg></response>`
+
+	err := Parse([]byte(data))
+	if err == nil {
+		t.Errorf("Error is nil")
+		return
+	}
+	e2, ok := err.(Panos)
+	if !ok {
+		t.Errorf("Not a panos error")
+		return
+	}
+	if e2.Msg != expected {
+		t.Errorf("Expected %q, got %q", expected, e2.Msg)
+	}
+}
+
+func TestSuccessCodeNotAnError(t *testing.T) {
+	for _, code := range []int{19, 20} {
+		data := fmt.Sprintf(`<response status="success" code="%d"/>`, code)
+		err := Parse([]byte(data))
+		if err != nil {
+			t.Errorf("code %d should not produce an error, got: %v", code, err)
+		}
+	}
+}

--- a/network/profiles/zone_protection/entry.go
+++ b/network/profiles/zone_protection/entry.go
@@ -1,0 +1,598 @@
+package zone_protection
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"github.com/PaloAltoNetworks/pango/filtering"
+	"github.com/PaloAltoNetworks/pango/generic"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
+)
+
+var (
+	_ filtering.Fielder = &Entry{}
+)
+
+// Entry represents a zone protection profile.
+type Entry struct {
+	Name                       string
+	Description                *string
+	Flood                      *Flood
+	Scan                       []ScanEntry
+	DiscardIpSpoof             *bool
+	DiscardStrictSourceRouting *bool
+	DiscardLooseSourceRouting  *bool
+	DiscardMalformedOption     *bool
+	RemoveTcpTimestamp         *bool
+	DiscardIpFrag              *bool
+	TcpSynWithData             *bool
+	StripTcpFastOpenAndData    *bool
+	StripMptcpOption           *string
+	Misc                       []generic.Xml
+	MiscAttributes             []xml.Attr
+}
+
+type Flood struct {
+	Syn    *FloodSyn
+	Icmp   *FloodProtocol
+	Icmpv6 *FloodProtocol
+	Udp    *FloodProtocol
+	Other  *FloodProtocol
+}
+
+type FloodSyn struct {
+	Enable     *bool
+	Red        *FloodRates
+	SynCookies *FloodRates
+}
+
+type FloodProtocol struct {
+	Enable *bool
+	Red    *FloodRates
+}
+
+type FloodRates struct {
+	AlarmRate    *int64
+	ActivateRate *int64
+	MaximalRate  *int64
+}
+
+type ScanEntry struct {
+	Name      string
+	Action    ScanAction
+	Interval  *int64
+	Threshold *int64
+}
+
+type ScanAction struct {
+	Alert   bool
+	Block   bool
+	BlockIp *ScanBlockIp
+}
+
+type ScanBlockIp struct {
+	TrackBy  *string
+	Duration *int64
+}
+
+// EntryObject interface methods.
+
+func (o *Entry) EntryName() string {
+	return o.Name
+}
+
+func (o *Entry) SetEntryName(name string) {
+	o.Name = name
+}
+
+func (o *Entry) GetMiscAttributes() []xml.Attr {
+	return o.MiscAttributes
+}
+
+func (o *Entry) SetMiscAttributes(attrs []xml.Attr) {
+	o.MiscAttributes = attrs
+}
+
+// XML types.
+
+type entryXml struct {
+	XMLName                    xml.Name       `xml:"entry"`
+	Name                       string         `xml:"name,attr"`
+	Description                *string        `xml:"description,omitempty"`
+	Flood                      *floodXml      `xml:"flood,omitempty"`
+	Scan                       *scanXml       `xml:"scan,omitempty"`
+	DiscardIpSpoof             *string        `xml:"discard-ip-spoof,omitempty"`
+	DiscardStrictSourceRouting *string        `xml:"discard-strict-source-routing,omitempty"`
+	DiscardLooseSourceRouting  *string        `xml:"discard-loose-source-routing,omitempty"`
+	DiscardMalformedOption     *string          `xml:"discard-malformed-option,omitempty"`
+	RemoveTcpTimestamp         *string          `xml:"remove-tcp-timestamp,omitempty"`
+	DiscardIpFrag              *string          `xml:"discard-ip-frag,omitempty"`
+	PacketBased                *packetBasedXml  `xml:"packet-based,omitempty"`
+	Misc                       []generic.Xml    `xml:",any"`
+	MiscAttributes             []xml.Attr       `xml:",any,attr"`
+}
+
+type packetBasedXml struct {
+	TcpSynWithData          *string `xml:"tcp-syn-with-data,omitempty"`
+	StripTcpFastOpenAndData *string `xml:"strip-tcp-fast-open-and-data,omitempty"`
+	StripMptcpOption        *string `xml:"strip-mptcp-option,omitempty"`
+}
+
+type floodXml struct {
+	Syn    *floodSynXml      `xml:"tcp-syn,omitempty"`
+	Icmp   *floodProtocolXml `xml:"icmp,omitempty"`
+	Icmpv6 *floodProtocolXml `xml:"icmpv6,omitempty"`
+	Udp    *floodProtocolXml `xml:"udp,omitempty"`
+	Other  *floodProtocolXml `xml:"other-ip,omitempty"`
+}
+
+type floodSynXml struct {
+	Enable     *string        `xml:"enable,omitempty"`
+	Red        *floodRatesXml `xml:"red,omitempty"`
+	SynCookies *floodRatesXml `xml:"syn-cookies,omitempty"`
+}
+
+type floodProtocolXml struct {
+	Enable *string        `xml:"enable,omitempty"`
+	Red    *floodRatesXml `xml:"red,omitempty"`
+}
+
+type floodRatesXml struct {
+	AlarmRate    *int64 `xml:"alarm-rate,omitempty"`
+	ActivateRate *int64 `xml:"activate-rate,omitempty"`
+	MaximalRate  *int64 `xml:"maximal-rate,omitempty"`
+}
+
+type scanXml struct {
+	Entries []scanEntryXml `xml:"entry"`
+}
+
+type scanEntryXml struct {
+	XMLName   xml.Name       `xml:"entry"`
+	Name      string         `xml:"name,attr"`
+	Action    *scanActionXml `xml:"action,omitempty"`
+	Interval  *int64         `xml:"interval,omitempty"`
+	Threshold *int64         `xml:"threshold,omitempty"`
+}
+
+type scanActionXml struct {
+	Alert   *emptyXml       `xml:"alert"`
+	Block   *emptyXml       `xml:"block"`
+	BlockIp *scanBlockIpXml `xml:"block-ip"`
+}
+
+type emptyXml struct{}
+
+type scanBlockIpXml struct {
+	TrackBy  *string `xml:"track-by,omitempty"`
+	Duration *int64  `xml:"duration,omitempty"`
+}
+
+type entryXmlContainer struct {
+	Answer []entryXml `xml:"entry"`
+}
+
+func (o *entryXmlContainer) Normalize() ([]*Entry, error) {
+	entries := make([]*Entry, 0, len(o.Answer))
+	for _, elt := range o.Answer {
+		obj, err := elt.UnmarshalToObject()
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, obj)
+	}
+	return entries, nil
+}
+
+func specifyEntry(source *Entry) (any, error) {
+	var obj entryXml
+	obj.MarshalFromObject(*source)
+	return obj, nil
+}
+
+func (o *entryXml) MarshalFromObject(s Entry) {
+	o.Name = s.Name
+	o.Description = s.Description
+	o.DiscardIpSpoof = util.YesNo(s.DiscardIpSpoof, nil)
+	o.DiscardStrictSourceRouting = util.YesNo(s.DiscardStrictSourceRouting, nil)
+	o.DiscardLooseSourceRouting = util.YesNo(s.DiscardLooseSourceRouting, nil)
+	o.DiscardMalformedOption = util.YesNo(s.DiscardMalformedOption, nil)
+	o.RemoveTcpTimestamp = util.YesNo(s.RemoveTcpTimestamp, nil)
+	o.DiscardIpFrag = util.YesNo(s.DiscardIpFrag, nil)
+	tcpSynWithData := util.YesNo(s.TcpSynWithData, nil)
+	stripTcpFastOpenAndData := util.YesNo(s.StripTcpFastOpenAndData, nil)
+	if tcpSynWithData != nil || stripTcpFastOpenAndData != nil || s.StripMptcpOption != nil {
+		o.PacketBased = &packetBasedXml{
+			TcpSynWithData:          tcpSynWithData,
+			StripTcpFastOpenAndData: stripTcpFastOpenAndData,
+			StripMptcpOption:        s.StripMptcpOption,
+		}
+	}
+	o.Misc = s.Misc
+	o.MiscAttributes = s.MiscAttributes
+
+	if len(s.Scan) > 0 {
+		scan := &scanXml{}
+		for _, se := range s.Scan {
+			sxml := scanEntryXml{
+				Name:      se.Name,
+				Interval:  se.Interval,
+				Threshold: se.Threshold,
+				Action:    &scanActionXml{},
+			}
+			if se.Action.Alert {
+				sxml.Action.Alert = &emptyXml{}
+			}
+			if se.Action.Block {
+				sxml.Action.Block = &emptyXml{}
+			}
+			if se.Action.BlockIp != nil {
+				sxml.Action.BlockIp = &scanBlockIpXml{
+					TrackBy:  se.Action.BlockIp.TrackBy,
+					Duration: se.Action.BlockIp.Duration,
+				}
+			}
+			scan.Entries = append(scan.Entries, sxml)
+		}
+		o.Scan = scan
+	}
+
+	if s.Flood != nil {
+		flood := &floodXml{}
+		if s.Flood.Syn != nil {
+			syn := &floodSynXml{
+				Enable: util.YesNo(s.Flood.Syn.Enable, nil),
+			}
+			if s.Flood.Syn.Red != nil {
+				syn.Red = &floodRatesXml{
+					AlarmRate:    s.Flood.Syn.Red.AlarmRate,
+					ActivateRate: s.Flood.Syn.Red.ActivateRate,
+					MaximalRate:  s.Flood.Syn.Red.MaximalRate,
+				}
+			}
+			if s.Flood.Syn.SynCookies != nil {
+				syn.SynCookies = &floodRatesXml{
+					AlarmRate:    s.Flood.Syn.SynCookies.AlarmRate,
+					ActivateRate: s.Flood.Syn.SynCookies.ActivateRate,
+					MaximalRate:  s.Flood.Syn.SynCookies.MaximalRate,
+				}
+			}
+			flood.Syn = syn
+		}
+		if s.Flood.Icmp != nil {
+			flood.Icmp = marshalFloodProtocol(s.Flood.Icmp)
+		}
+		if s.Flood.Icmpv6 != nil {
+			flood.Icmpv6 = marshalFloodProtocol(s.Flood.Icmpv6)
+		}
+		if s.Flood.Udp != nil {
+			flood.Udp = marshalFloodProtocol(s.Flood.Udp)
+		}
+		if s.Flood.Other != nil {
+			flood.Other = marshalFloodProtocol(s.Flood.Other)
+		}
+		o.Flood = flood
+	}
+}
+
+func marshalFloodProtocol(p *FloodProtocol) *floodProtocolXml {
+	obj := &floodProtocolXml{
+		Enable: util.YesNo(p.Enable, nil),
+	}
+	if p.Red != nil {
+		obj.Red = &floodRatesXml{
+			AlarmRate:    p.Red.AlarmRate,
+			ActivateRate: p.Red.ActivateRate,
+			MaximalRate:  p.Red.MaximalRate,
+		}
+	}
+	return obj
+}
+
+func unmarshalFloodProtocol(p *floodProtocolXml) *FloodProtocol {
+	if p == nil {
+		return nil
+	}
+	obj := &FloodProtocol{
+		Enable: util.AsBool(p.Enable, nil),
+	}
+	if p.Red != nil {
+		obj.Red = &FloodRates{
+			AlarmRate:    p.Red.AlarmRate,
+			ActivateRate: p.Red.ActivateRate,
+			MaximalRate:  p.Red.MaximalRate,
+		}
+	}
+	return obj
+}
+
+func (o entryXml) UnmarshalToObject() (*Entry, error) {
+	result := &Entry{
+		Name:                       o.Name,
+		Description:                o.Description,
+		DiscardIpSpoof:             util.AsBool(o.DiscardIpSpoof, nil),
+		DiscardStrictSourceRouting: util.AsBool(o.DiscardStrictSourceRouting, nil),
+		DiscardLooseSourceRouting:  util.AsBool(o.DiscardLooseSourceRouting, nil),
+		DiscardMalformedOption:     util.AsBool(o.DiscardMalformedOption, nil),
+		RemoveTcpTimestamp:         util.AsBool(o.RemoveTcpTimestamp, nil),
+		DiscardIpFrag:              util.AsBool(o.DiscardIpFrag, nil),
+		Misc:                       o.Misc,
+		MiscAttributes:             o.MiscAttributes,
+	}
+	if o.PacketBased != nil {
+		result.TcpSynWithData = util.AsBool(o.PacketBased.TcpSynWithData, nil)
+		result.StripTcpFastOpenAndData = util.AsBool(o.PacketBased.StripTcpFastOpenAndData, nil)
+		result.StripMptcpOption = o.PacketBased.StripMptcpOption
+	}
+
+	if o.Scan != nil {
+		for _, se := range o.Scan.Entries {
+			entry := ScanEntry{
+				Name:      se.Name,
+				Interval:  se.Interval,
+				Threshold: se.Threshold,
+			}
+			if se.Action != nil {
+				entry.Action.Alert = se.Action.Alert != nil
+				entry.Action.Block = se.Action.Block != nil
+				if se.Action.BlockIp != nil {
+					entry.Action.BlockIp = &ScanBlockIp{
+						TrackBy:  se.Action.BlockIp.TrackBy,
+						Duration: se.Action.BlockIp.Duration,
+					}
+				}
+			}
+			result.Scan = append(result.Scan, entry)
+		}
+	}
+
+	if o.Flood != nil {
+		flood := &Flood{}
+		if o.Flood.Syn != nil {
+			syn := &FloodSyn{
+				Enable: util.AsBool(o.Flood.Syn.Enable, nil),
+			}
+			if o.Flood.Syn.Red != nil {
+				syn.Red = &FloodRates{
+					AlarmRate:    o.Flood.Syn.Red.AlarmRate,
+					ActivateRate: o.Flood.Syn.Red.ActivateRate,
+					MaximalRate:  o.Flood.Syn.Red.MaximalRate,
+				}
+			}
+			if o.Flood.Syn.SynCookies != nil {
+				syn.SynCookies = &FloodRates{
+					AlarmRate:    o.Flood.Syn.SynCookies.AlarmRate,
+					ActivateRate: o.Flood.Syn.SynCookies.ActivateRate,
+					MaximalRate:  o.Flood.Syn.SynCookies.MaximalRate,
+				}
+			}
+			flood.Syn = syn
+		}
+		flood.Icmp = unmarshalFloodProtocol(o.Flood.Icmp)
+		flood.Icmpv6 = unmarshalFloodProtocol(o.Flood.Icmpv6)
+		flood.Udp = unmarshalFloodProtocol(o.Flood.Udp)
+		flood.Other = unmarshalFloodProtocol(o.Flood.Other)
+		result.Flood = flood
+	}
+
+	return result, nil
+}
+
+func (e *Entry) Field(v string) (any, error) {
+	if v == "name" || v == "Name" {
+		return e.Name, nil
+	}
+	if v == "description" || v == "Description" {
+		return e.Description, nil
+	}
+	if v == "flood" || v == "Flood" {
+		return e.Flood, nil
+	}
+	if v == "discard_ip_spoof" || v == "DiscardIpSpoof" {
+		return e.DiscardIpSpoof, nil
+	}
+	if v == "discard_strict_source_routing" || v == "DiscardStrictSourceRouting" {
+		return e.DiscardStrictSourceRouting, nil
+	}
+	if v == "discard_loose_source_routing" || v == "DiscardLooseSourceRouting" {
+		return e.DiscardLooseSourceRouting, nil
+	}
+	if v == "scan" || v == "Scan" {
+		return e.Scan, nil
+	}
+	if v == "discard_malformed_option" || v == "DiscardMalformedOption" {
+		return e.DiscardMalformedOption, nil
+	}
+	if v == "remove_tcp_timestamp" || v == "RemoveTcpTimestamp" {
+		return e.RemoveTcpTimestamp, nil
+	}
+	if v == "discard_ip_frag" || v == "DiscardIpFrag" {
+		return e.DiscardIpFrag, nil
+	}
+	if v == "tcp_syn_with_data" || v == "TcpSynWithData" {
+		return e.TcpSynWithData, nil
+	}
+	if v == "strip_tcp_fast_open_and_data" || v == "StripTcpFastOpenAndData" {
+		return e.StripTcpFastOpenAndData, nil
+	}
+	if v == "strip_mptcp_option" || v == "StripMptcpOption" {
+		return e.StripMptcpOption, nil
+	}
+	return nil, fmt.Errorf("unknown field")
+}
+
+func Versioning(vn version.Number) (Specifier, Normalizer, error) {
+	return specifyEntry, &entryXmlContainer{}, nil
+}
+
+func SpecMatches(a, b *Entry) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if (a == nil && b != nil) || (a != nil && b == nil) {
+		return false
+	}
+	return a.matches(b)
+}
+
+func (o *Entry) matches(other *Entry) bool {
+	if o == nil && other == nil {
+		return true
+	}
+	if (o == nil && other != nil) || (o != nil && other == nil) {
+		return false
+	}
+	if !util.StringsMatch(o.Description, other.Description) {
+		return false
+	}
+	if !o.floodMatches(other) {
+		return false
+	}
+	if !util.BoolsMatch(o.DiscardIpSpoof, other.DiscardIpSpoof) {
+		return false
+	}
+	if !util.BoolsMatch(o.DiscardStrictSourceRouting, other.DiscardStrictSourceRouting) {
+		return false
+	}
+	if !util.BoolsMatch(o.DiscardLooseSourceRouting, other.DiscardLooseSourceRouting) {
+		return false
+	}
+	if !scanEntriesMatch(o.Scan, other.Scan) {
+		return false
+	}
+	if !util.BoolsMatch(o.DiscardMalformedOption, other.DiscardMalformedOption) {
+		return false
+	}
+	if !util.BoolsMatch(o.RemoveTcpTimestamp, other.RemoveTcpTimestamp) {
+		return false
+	}
+	if !util.BoolsMatch(o.DiscardIpFrag, other.DiscardIpFrag) {
+		return false
+	}
+	if !util.BoolsMatch(o.TcpSynWithData, other.TcpSynWithData) {
+		return false
+	}
+	if !util.BoolsMatch(o.StripTcpFastOpenAndData, other.StripTcpFastOpenAndData) {
+		return false
+	}
+	if !util.StringsMatch(o.StripMptcpOption, other.StripMptcpOption) {
+		return false
+	}
+	return true
+}
+
+func (o *Entry) floodMatches(other *Entry) bool {
+	if o.Flood == nil && other.Flood == nil {
+		return true
+	}
+	if (o.Flood == nil) != (other.Flood == nil) {
+		return false
+	}
+	if !floodSynMatches(o.Flood.Syn, other.Flood.Syn) {
+		return false
+	}
+	if !floodProtocolMatches(o.Flood.Icmp, other.Flood.Icmp) {
+		return false
+	}
+	if !floodProtocolMatches(o.Flood.Icmpv6, other.Flood.Icmpv6) {
+		return false
+	}
+	if !floodProtocolMatches(o.Flood.Udp, other.Flood.Udp) {
+		return false
+	}
+	if !floodProtocolMatches(o.Flood.Other, other.Flood.Other) {
+		return false
+	}
+	return true
+}
+
+func floodSynMatches(a, b *FloodSyn) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if !util.BoolsMatch(a.Enable, b.Enable) {
+		return false
+	}
+	if !floodRatesMatch(a.Red, b.Red) {
+		return false
+	}
+	if !floodRatesMatch(a.SynCookies, b.SynCookies) {
+		return false
+	}
+	return true
+}
+
+func floodProtocolMatches(a, b *FloodProtocol) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if !util.BoolsMatch(a.Enable, b.Enable) {
+		return false
+	}
+	if !floodRatesMatch(a.Red, b.Red) {
+		return false
+	}
+	return true
+}
+
+func scanEntriesMatch(a, b []ScanEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name {
+			return false
+		}
+		if a[i].Action.Alert != b[i].Action.Alert {
+			return false
+		}
+		if a[i].Action.Block != b[i].Action.Block {
+			return false
+		}
+		aBI, bBI := a[i].Action.BlockIp, b[i].Action.BlockIp
+		if (aBI == nil) != (bBI == nil) {
+			return false
+		}
+		if aBI != nil {
+			if !util.StringsMatch(aBI.TrackBy, bBI.TrackBy) {
+				return false
+			}
+			if !util.Ints64Match(aBI.Duration, bBI.Duration) {
+				return false
+			}
+		}
+		if !util.Ints64Match(a[i].Interval, b[i].Interval) {
+			return false
+		}
+		if !util.Ints64Match(a[i].Threshold, b[i].Threshold) {
+			return false
+		}
+	}
+	return true
+}
+
+func floodRatesMatch(a, b *FloodRates) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if !util.Ints64Match(a.AlarmRate, b.AlarmRate) {
+		return false
+	}
+	if !util.Ints64Match(a.ActivateRate, b.ActivateRate) {
+		return false
+	}
+	if !util.Ints64Match(a.MaximalRate, b.MaximalRate) {
+		return false
+	}
+	return true
+}

--- a/network/profiles/zone_protection/entry_test.go
+++ b/network/profiles/zone_protection/entry_test.go
@@ -1,0 +1,211 @@
+package zone_protection_test
+
+import (
+	"encoding/xml"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	zp "github.com/PaloAltoNetworks/pango/network/profiles/zone_protection"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
+)
+
+func TestZoneProtection(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ZoneProtection Suite")
+}
+
+var _ = Describe("Zone Protection Entry", func() {
+	var (
+		specifier  zp.Specifier
+		normalizer zp.Normalizer
+	)
+
+	BeforeEach(func() {
+		vn, _ := version.New("10.2.0")
+		var err error
+		specifier, normalizer, err = zp.Versioning(vn)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("XML tag fixes", func() {
+		Context("other-ip flood field", func() {
+			It("marshals Other flood as <other-ip>, not <other>", func() {
+				enable := true
+				entry := &zp.Entry{
+					Name: "test",
+					Flood: &zp.Flood{
+						Other: &zp.FloodProtocol{Enable: &enable},
+					},
+				}
+				spec, err := specifier(entry)
+				Expect(err).ToNot(HaveOccurred())
+
+				b, err := xml.Marshal(spec)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(b)).To(ContainSubstring("<other-ip>"))
+				Expect(string(b)).ToNot(ContainSubstring("<other>"))
+			})
+
+			It("unmarshals <other-ip> back into Other field", func() {
+				data := []byte(`<result><entry name="test"><flood><other-ip><enable>yes</enable></other-ip></flood></entry></result>`)
+				err := xml.Unmarshal(data, &normalizer)
+				Expect(err).ToNot(HaveOccurred())
+
+				entries, err := normalizer.Normalize()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(HaveLen(1))
+				Expect(entries[0].Flood).ToNot(BeNil())
+				Expect(entries[0].Flood.Other).ToNot(BeNil())
+				Expect(entries[0].Flood.Other.Enable).ToNot(BeNil())
+				Expect(*entries[0].Flood.Other.Enable).To(BeTrue())
+			})
+		})
+
+		Context("packet-based wrapper", func() {
+			It("marshals TcpSynWithData under <packet-based>", func() {
+				val := true
+				entry := &zp.Entry{
+					Name:           "test",
+					TcpSynWithData: &val,
+				}
+				spec, err := specifier(entry)
+				Expect(err).ToNot(HaveOccurred())
+
+				b, err := xml.Marshal(spec)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(b)).To(ContainSubstring("<packet-based>"))
+				Expect(string(b)).To(ContainSubstring("<tcp-syn-with-data>yes</tcp-syn-with-data>"))
+			})
+
+			It("does not emit <packet-based> when all three fields are nil", func() {
+				entry := &zp.Entry{Name: "test"}
+				spec, err := specifier(entry)
+				Expect(err).ToNot(HaveOccurred())
+
+				b, err := xml.Marshal(spec)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(b)).ToNot(ContainSubstring("<packet-based>"))
+			})
+
+			It("unmarshals <packet-based> fields back into Entry", func() {
+				data := []byte(`<result><entry name="test"><packet-based><tcp-syn-with-data>yes</tcp-syn-with-data><strip-tcp-fast-open-and-data>no</strip-tcp-fast-open-and-data></packet-based></entry></result>`)
+				err := xml.Unmarshal(data, &normalizer)
+				Expect(err).ToNot(HaveOccurred())
+
+				entries, err := normalizer.Normalize()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(HaveLen(1))
+				e := entries[0]
+				Expect(e.TcpSynWithData).ToNot(BeNil())
+				Expect(*e.TcpSynWithData).To(BeTrue())
+				Expect(e.StripTcpFastOpenAndData).ToNot(BeNil())
+				Expect(*e.StripTcpFastOpenAndData).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("New fields", func() {
+		Context("discard-strict-source-routing and discard-loose-source-routing", func() {
+			It("marshals both fields at top level", func() {
+				t := true
+				entry := &zp.Entry{
+					Name:                       "test",
+					DiscardStrictSourceRouting: &t,
+					DiscardLooseSourceRouting:  &t,
+				}
+				spec, err := specifier(entry)
+				Expect(err).ToNot(HaveOccurred())
+
+				b, err := xml.Marshal(spec)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(b)).To(ContainSubstring("<discard-strict-source-routing>yes</discard-strict-source-routing>"))
+				Expect(string(b)).To(ContainSubstring("<discard-loose-source-routing>yes</discard-loose-source-routing>"))
+			})
+
+			It("unmarshals both fields", func() {
+				data := []byte(`<result><entry name="test"><discard-strict-source-routing>yes</discard-strict-source-routing><discard-loose-source-routing>no</discard-loose-source-routing></entry></result>`)
+				err := xml.Unmarshal(data, &normalizer)
+				Expect(err).ToNot(HaveOccurred())
+
+				entries, err := normalizer.Normalize()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(HaveLen(1))
+				e := entries[0]
+				Expect(e.DiscardStrictSourceRouting).ToNot(BeNil())
+				Expect(*e.DiscardStrictSourceRouting).To(BeTrue())
+				Expect(e.DiscardLooseSourceRouting).ToNot(BeNil())
+				Expect(*e.DiscardLooseSourceRouting).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("Round-trip", func() {
+		It("marshals and unmarshals a full entry without data loss", func() {
+			alarmRate := int64(10000)
+			activateRate := int64(10000)
+			maximalRate := int64(40000)
+			enable := true
+			discard := true
+
+			original := &zp.Entry{
+				Name:                       "full-test",
+				Description:                util.String("Managed by Terraform"),
+				DiscardIpSpoof:             &discard,
+				DiscardStrictSourceRouting: &discard,
+				DiscardLooseSourceRouting:  &discard,
+				Flood: &zp.Flood{
+					Syn: &zp.FloodSyn{
+						Enable: &enable,
+						Red: &zp.FloodRates{
+							AlarmRate:    &alarmRate,
+							ActivateRate: &activateRate,
+							MaximalRate:  &maximalRate,
+						},
+					},
+					Icmp: &zp.FloodProtocol{
+						Enable: &enable,
+						Red: &zp.FloodRates{
+							AlarmRate:    &alarmRate,
+							ActivateRate: &activateRate,
+							MaximalRate:  &maximalRate,
+						},
+					},
+					Other: &zp.FloodProtocol{
+						Enable: &enable,
+					},
+				},
+			}
+
+			spec, err := specifier(original)
+			Expect(err).ToNot(HaveOccurred())
+
+			b, err := xml.Marshal(spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			wrapped := append([]byte("<result>"), append(b, []byte("</result>")...)...)
+			err = xml.Unmarshal(wrapped, &normalizer)
+			Expect(err).ToNot(HaveOccurred())
+
+			entries, err := normalizer.Normalize()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(entries).To(HaveLen(1))
+
+			got := entries[0]
+			Expect(got.Name).To(Equal(original.Name))
+			Expect(got.Description).ToNot(BeNil())
+			Expect(*got.Description).To(Equal(*original.Description))
+			Expect(got.DiscardIpSpoof).ToNot(BeNil())
+			Expect(*got.DiscardIpSpoof).To(BeTrue())
+			Expect(got.DiscardStrictSourceRouting).ToNot(BeNil())
+			Expect(*got.DiscardStrictSourceRouting).To(BeTrue())
+			Expect(got.Flood).ToNot(BeNil())
+			Expect(got.Flood.Other).ToNot(BeNil())
+			Expect(*got.Flood.Other.Enable).To(BeTrue())
+
+			Expect(zp.SpecMatches(original, got)).To(BeTrue())
+		})
+	})
+})

--- a/network/profiles/zone_protection/interfaces.go
+++ b/network/profiles/zone_protection/interfaces.go
@@ -1,0 +1,7 @@
+package zone_protection
+
+type Specifier func(*Entry) (any, error)
+
+type Normalizer interface {
+	Normalize() ([]*Entry, error)
+}

--- a/network/profiles/zone_protection/location.go
+++ b/network/profiles/zone_protection/location.go
@@ -1,0 +1,197 @@
+package zone_protection
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PaloAltoNetworks/pango/errors"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
+)
+
+type ImportLocation interface {
+	XpathForLocation(version.Number, util.ILocation) ([]string, error)
+	MarshalPangoXML([]string) (string, error)
+	UnmarshalPangoXML([]byte) ([]string, error)
+}
+
+type Location struct {
+	Ngfw          *NgfwLocation          `json:"ngfw,omitempty"`
+	Template      *TemplateLocation      `json:"template,omitempty"`
+	TemplateStack *TemplateStackLocation `json:"template_stack,omitempty"`
+}
+
+type NgfwLocation struct {
+	NgfwDevice string `json:"ngfw_device"`
+}
+
+type TemplateLocation struct {
+	NgfwDevice     string `json:"ngfw_device"`
+	PanoramaDevice string `json:"panorama_device"`
+	Template       string `json:"template"`
+}
+
+type TemplateStackLocation struct {
+	NgfwDevice     string `json:"ngfw_device"`
+	PanoramaDevice string `json:"panorama_device"`
+	TemplateStack  string `json:"template_stack"`
+}
+
+func NewNgfwLocation() *Location {
+	return &Location{Ngfw: &NgfwLocation{
+		NgfwDevice: "localhost.localdomain",
+	}}
+}
+
+func NewTemplateLocation() *Location {
+	return &Location{Template: &TemplateLocation{
+		NgfwDevice:     "localhost.localdomain",
+		PanoramaDevice: "localhost.localdomain",
+		Template:       "",
+	}}
+}
+
+func NewTemplateStackLocation() *Location {
+	return &Location{TemplateStack: &TemplateStackLocation{
+		NgfwDevice:     "localhost.localdomain",
+		PanoramaDevice: "localhost.localdomain",
+		TemplateStack:  "",
+	}}
+}
+
+func (o Location) IsValid() error {
+	count := 0
+
+	switch {
+	case o.Ngfw != nil:
+		if o.Ngfw.NgfwDevice == "" {
+			return fmt.Errorf("NgfwDevice is unspecified")
+		}
+		count++
+	case o.Template != nil:
+		if o.Template.NgfwDevice == "" {
+			return fmt.Errorf("NgfwDevice is unspecified")
+		}
+		if o.Template.PanoramaDevice == "" {
+			return fmt.Errorf("PanoramaDevice is unspecified")
+		}
+		if o.Template.Template == "" {
+			return fmt.Errorf("Template is unspecified")
+		}
+		count++
+	case o.TemplateStack != nil:
+		if o.TemplateStack.NgfwDevice == "" {
+			return fmt.Errorf("NgfwDevice is unspecified")
+		}
+		if o.TemplateStack.PanoramaDevice == "" {
+			return fmt.Errorf("PanoramaDevice is unspecified")
+		}
+		if o.TemplateStack.TemplateStack == "" {
+			return fmt.Errorf("TemplateStack is unspecified")
+		}
+		count++
+	}
+
+	if count == 0 {
+		return fmt.Errorf("no path specified")
+	}
+	if count > 1 {
+		return fmt.Errorf("multiple paths specified: only one should be specified")
+	}
+
+	return nil
+}
+
+func (o Location) LocationFilter() *string {
+	return nil
+}
+
+func (o Location) XpathPrefix(vn version.Number) ([]string, error) {
+	var ans []string
+
+	switch {
+	case o.Ngfw != nil:
+		if o.Ngfw.NgfwDevice == "" {
+			return nil, fmt.Errorf("NgfwDevice is unspecified")
+		}
+		ans = []string{
+			"config",
+			"devices",
+			util.AsEntryXpath(o.Ngfw.NgfwDevice),
+		}
+	case o.Template != nil:
+		if o.Template.NgfwDevice == "" {
+			return nil, fmt.Errorf("NgfwDevice is unspecified")
+		}
+		if o.Template.PanoramaDevice == "" {
+			return nil, fmt.Errorf("PanoramaDevice is unspecified")
+		}
+		if o.Template.Template == "" {
+			return nil, fmt.Errorf("Template is unspecified")
+		}
+		ans = []string{
+			"config",
+			"devices",
+			util.AsEntryXpath(o.Template.PanoramaDevice),
+			"template",
+			util.AsEntryXpath(o.Template.Template),
+			"config",
+			"devices",
+			util.AsEntryXpath(o.Template.NgfwDevice),
+		}
+	case o.TemplateStack != nil:
+		if o.TemplateStack.NgfwDevice == "" {
+			return nil, fmt.Errorf("NgfwDevice is unspecified")
+		}
+		if o.TemplateStack.PanoramaDevice == "" {
+			return nil, fmt.Errorf("PanoramaDevice is unspecified")
+		}
+		if o.TemplateStack.TemplateStack == "" {
+			return nil, fmt.Errorf("TemplateStack is unspecified")
+		}
+		ans = []string{
+			"config",
+			"devices",
+			util.AsEntryXpath(o.TemplateStack.PanoramaDevice),
+			"template-stack",
+			util.AsEntryXpath(o.TemplateStack.TemplateStack),
+			"config",
+			"devices",
+			util.AsEntryXpath(o.TemplateStack.NgfwDevice),
+		}
+	default:
+		return nil, errors.NoLocationSpecifiedError
+	}
+
+	return ans, nil
+}
+
+func (o Location) XpathWithComponents(vn version.Number, components ...string) ([]string, error) {
+	if len(components) != 1 {
+		return nil, fmt.Errorf("invalid number of arguments for XpathWithComponents() call")
+	}
+
+	{
+		component := components[0]
+		if component != "entry" {
+			if !strings.HasPrefix(component, "entry[@name=\"]") && !strings.HasPrefix(component, "entry[@name='") {
+				return nil, errors.NewInvalidXpathComponentError(fmt.Sprintf("Name must be formatted as entry: %s", component))
+			}
+			if !strings.HasSuffix(component, "\"]") && !strings.HasSuffix(component, "']") {
+				return nil, errors.NewInvalidXpathComponentError(fmt.Sprintf("Name must be formatted as entry: %s", component))
+			}
+		}
+	}
+
+	ans, err := o.XpathPrefix(vn)
+	if err != nil {
+		return nil, err
+	}
+
+	ans = append(ans, "network")
+	ans = append(ans, "profiles")
+	ans = append(ans, "zone-protection-profile")
+	ans = append(ans, components[0])
+
+	return ans, nil
+}

--- a/network/profiles/zone_protection/service.go
+++ b/network/profiles/zone_protection/service.go
@@ -1,0 +1,283 @@
+package zone_protection
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/PaloAltoNetworks/pango/errors"
+	"github.com/PaloAltoNetworks/pango/filtering"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/xmlapi"
+)
+
+type Service struct {
+	client util.PangoClient
+}
+
+func NewService(client util.PangoClient) *Service {
+	return &Service{client: client}
+}
+
+// Create adds new item, then returns the result.
+func (s *Service) Create(ctx context.Context, loc Location, entry *Entry) (*Entry, error) {
+	if entry.Name == "" {
+		return nil, errors.NameNotSpecifiedError
+	}
+
+	vn := s.client.Versioning()
+	path, err := loc.XpathWithComponents(vn, util.AsEntryXpath(entry.Name))
+	if err != nil {
+		return nil, err
+	}
+	err = s.CreateWithXpath(ctx, util.AsXpath(path[:len(path)-1]), entry)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.ReadWithXpath(ctx, util.AsXpath(path), "get")
+}
+
+func (s *Service) CreateWithXpath(ctx context.Context, xpath string, entry *Entry) error {
+	vn := s.client.Versioning()
+	specifier, _, err := Versioning(vn)
+	if err != nil {
+		return err
+	}
+	createSpec, err := specifier(entry)
+	if err != nil {
+		return err
+	}
+
+	cmd := &xmlapi.Config{
+		Action:  "set",
+		Xpath:   xpath,
+		Element: createSpec,
+		Target:  s.client.GetTarget(),
+	}
+
+	if _, _, err = s.client.Communicate(ctx, cmd, false, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Read returns the given config object, using the specified action ("get" or "show").
+func (s *Service) Read(ctx context.Context, loc Location, name, action string) (*Entry, error) {
+	return s.read(ctx, loc, name, action)
+}
+
+func (s *Service) ReadWithXpath(ctx context.Context, xpath string, action string) (*Entry, error) {
+	vn := s.client.Versioning()
+	_, normalizer, err := Versioning(vn)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := &xmlapi.Config{
+		Action: action,
+		Xpath:  xpath,
+		Target: s.client.GetTarget(),
+	}
+
+	if _, _, err = s.client.Communicate(ctx, cmd, true, normalizer); err != nil {
+		if err.Error() == "No such node" && action == "show" {
+			return nil, errors.ObjectNotFound()
+		}
+		return nil, err
+	}
+
+	list, err := normalizer.Normalize()
+	if err != nil {
+		return nil, err
+	} else if len(list) != 1 {
+		return nil, fmt.Errorf("expected to %q 1 entry, got %d", action, len(list))
+	}
+
+	return list[0], nil
+}
+
+func (s *Service) read(ctx context.Context, loc Location, value, action string) (*Entry, error) {
+	if value == "" {
+		return nil, errors.NameNotSpecifiedError
+	}
+	vn := s.client.Versioning()
+	path, err := loc.XpathWithComponents(vn, value)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.ReadWithXpath(ctx, util.AsXpath(path), action)
+}
+
+func (s *Service) Update(ctx context.Context, loc Location, entry *Entry, name string) (*Entry, error) {
+	if entry.Name == "" {
+		return nil, errors.NameNotSpecifiedError
+	}
+
+	xpath, err := loc.XpathWithComponents(s.client.Versioning(), entry.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.UpdateWithXpath(ctx, util.AsXpath(xpath), entry, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.ReadWithXpath(ctx, util.AsXpath(xpath), "get")
+}
+
+func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *Entry, name string) error {
+	vn := s.client.Versioning()
+	updates := xmlapi.NewMultiConfig(2)
+	specifier, _, err := Versioning(vn)
+	if err != nil {
+		return err
+	}
+
+	var old *Entry
+	if name != "" && name != entry.Name {
+		old, err = s.ReadWithXpath(ctx, xpath, "get")
+		if err != nil {
+			return err
+		}
+
+		if old != nil {
+			return errors.ObjectExists
+		}
+
+		updates.Add(&xmlapi.Config{
+			Action:  "rename",
+			Xpath:   util.AsXpath(xpath),
+			NewName: entry.Name,
+			Target:  s.client.GetTarget(),
+		})
+	} else {
+		old, err = s.ReadWithXpath(ctx, xpath, "get")
+		if err != nil {
+			return err
+		}
+
+		if old == nil {
+			return errors.ObjectNotFound()
+		}
+
+		if SpecMatches(entry, old) {
+			return nil
+		}
+
+		updateSpec, err := specifier(entry)
+		if err != nil {
+			return err
+		}
+
+		updates.Add(&xmlapi.Config{
+			Action:  "edit",
+			Xpath:   util.AsXpath(xpath),
+			Element: updateSpec,
+			Target:  s.client.GetTarget(),
+		})
+	}
+
+	if len(updates.Operations) != 0 {
+		if _, _, _, err = s.client.MultiConfig(ctx, updates, false, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Delete deletes the given item.
+func (s *Service) Delete(ctx context.Context, loc Location, name ...string) error {
+	return s.delete(ctx, loc, name)
+}
+
+func (s *Service) delete(ctx context.Context, loc Location, values []string) error {
+	for _, value := range values {
+		if value == "" {
+			return errors.NameNotSpecifiedError
+		}
+	}
+
+	vn := s.client.Versioning()
+	deletes := xmlapi.NewMultiConfig(len(values))
+	for _, value := range values {
+		path, err := loc.XpathWithComponents(vn, util.AsEntryXpath(value))
+		if err != nil {
+			return err
+		}
+		deletes.Add(&xmlapi.Config{
+			Action: "delete",
+			Xpath:  util.AsXpath(path),
+			Target: s.client.GetTarget(),
+		})
+	}
+
+	_, _, _, err := s.client.MultiConfig(ctx, deletes, false, nil)
+	return err
+}
+
+// List returns a list of objects using the given action ("get" or "show").
+// Params filter and quote are for client side filtering.
+func (s *Service) List(ctx context.Context, loc Location, action, filter, quote string) ([]*Entry, error) {
+	return s.list(ctx, loc, action, filter, quote)
+}
+
+func (s *Service) list(ctx context.Context, loc Location, action, filter, quote string) ([]*Entry, error) {
+	xpath, err := loc.XpathWithComponents(s.client.Versioning(), util.AsEntryXpath(""))
+	if err != nil {
+		return nil, err
+	}
+
+	return s.ListWithXpath(ctx, util.AsXpath(xpath), action, filter, quote)
+}
+
+func (s *Service) ListWithXpath(ctx context.Context, xpath string, action, filter, quote string) ([]*Entry, error) {
+	var logic *filtering.Group
+	if filter != "" {
+		var err error
+		logic, err = filtering.Parse(filter, quote)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	vn := s.client.Versioning()
+	_, normalizer, err := Versioning(vn)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := &xmlapi.Config{
+		Action: action,
+		Xpath:  util.AsXpath(xpath),
+		Target: s.client.GetTarget(),
+	}
+
+	if _, _, err = s.client.Communicate(ctx, cmd, true, normalizer); err != nil {
+		if err.Error() == "No such node" && action == "show" {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	listing, err := normalizer.Normalize()
+	if err != nil || logic == nil {
+		return listing, err
+	}
+
+	filtered := make([]*Entry, 0, len(listing))
+	for _, x := range listing {
+		ok, err := logic.Matches(x)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			filtered = append(filtered, x)
+		}
+	}
+
+	return filtered, nil
+}

--- a/objects/profiles/decryption/entry.go
+++ b/objects/profiles/decryption/entry.go
@@ -20,12 +20,11 @@ var (
 
 // Entry represents a PAN-OS decryption profile.
 type Entry struct {
-	Name                string
-	Description         *string
-	SslForwardProxy     *SslForwardProxy
+	Name                 string
+	SslForwardProxy      *SslForwardProxy
 	SslInboundInspection *SslInboundInspection
-	SslNoProxy          *SslNoProxy
-	SslProtocolSettings *SslProtocolSettings
+	SslNoProxy           *SslNoProxy
+	SslProtocolSettings  *SslProtocolSettings
 
 	Misc           []generic.Xml
 	MiscAttributes []xml.Attr
@@ -46,10 +45,11 @@ type SslForwardProxy struct {
 }
 
 type SslInboundInspection struct {
-	BlockIfHsmUnavailable   *bool
-	BlockIfNoResource       *bool
-	BlockUnsupportedCipher  *bool
-	BlockUnsupportedVersion *bool
+	BlockIfHsmUnavailable         *bool
+	BlockIfNoResource             *bool
+	BlockTls13DowngradeNoResource *bool
+	BlockUnsupportedCipher        *bool
+	BlockUnsupportedVersion       *bool
 }
 
 type SslNoProxy struct {
@@ -105,15 +105,14 @@ type entryXmlContainer struct {
 }
 
 type entryXml struct {
-	XMLName              xml.Name                  `xml:"entry"`
-	Name                 string                    `xml:"name,attr"`
-	Description          *string                   `xml:"description,omitempty"`
-	SslForwardProxy      *sslForwardProxyXml       `xml:"ssl-forward-proxy,omitempty"`
-	SslInboundInspection *sslInboundInspectionXml  `xml:"ssl-inbound-inspection,omitempty"`
-	SslNoProxy           *sslNoProxyXml            `xml:"ssl-no-proxy,omitempty"`
-	SslProtocolSettings  *sslProtocolSettingsXml   `xml:"ssl-protocol-settings,omitempty"`
-	Misc                 []generic.Xml             `xml:",any"`
-	MiscAttributes       []xml.Attr                `xml:",any,attr"`
+	XMLName              xml.Name                 `xml:"entry"`
+	Name                 string                   `xml:"name,attr"`
+	SslForwardProxy      *sslForwardProxyXml      `xml:"ssl-forward-proxy,omitempty"`
+	SslInboundInspection *sslInboundInspectionXml `xml:"ssl-inbound-proxy,omitempty"`
+	SslNoProxy           *sslNoProxyXml           `xml:"ssl-no-proxy,omitempty"`
+	SslProtocolSettings  *sslProtocolSettingsXml  `xml:"ssl-protocol-settings,omitempty"`
+	Misc                 []generic.Xml            `xml:",any"`
+	MiscAttributes       []xml.Attr               `xml:",any,attr"`
 }
 
 type sslForwardProxyXml struct {
@@ -131,10 +130,11 @@ type sslForwardProxyXml struct {
 }
 
 type sslInboundInspectionXml struct {
-	BlockIfHsmUnavailable   *string `xml:"block-if-hsm-unavailable,omitempty"`
-	BlockIfNoResource       *string `xml:"block-if-no-resource,omitempty"`
-	BlockUnsupportedCipher  *string `xml:"block-unsupported-cipher,omitempty"`
-	BlockUnsupportedVersion *string `xml:"block-unsupported-version,omitempty"`
+	BlockIfHsmUnavailable         *string `xml:"block-if-hsm-unavailable,omitempty"`
+	BlockIfNoResource             *string `xml:"block-if-no-resource,omitempty"`
+	BlockTls13DowngradeNoResource *string `xml:"block-tls13-downgrade-no-resource,omitempty"`
+	BlockUnsupportedCipher        *string `xml:"block-unsupported-cipher,omitempty"`
+	BlockUnsupportedVersion       *string `xml:"block-unsupported-version,omitempty"`
 }
 
 type sslNoProxyXml struct {
@@ -180,7 +180,6 @@ func (o *entryXmlContainer) Normalize() ([]*Entry, error) {
 func specifyEntry(o *Entry) (any, error) {
 	entry := entryXml{
 		Name:           o.Name,
-		Description:    o.Description,
 		Misc:           o.Misc,
 		MiscAttributes: o.MiscAttributes,
 	}
@@ -203,10 +202,11 @@ func specifyEntry(o *Entry) (any, error) {
 
 	if o.SslInboundInspection != nil {
 		entry.SslInboundInspection = &sslInboundInspectionXml{
-			BlockIfHsmUnavailable:   util.YesNo(o.SslInboundInspection.BlockIfHsmUnavailable, nil),
-			BlockIfNoResource:       util.YesNo(o.SslInboundInspection.BlockIfNoResource, nil),
-			BlockUnsupportedCipher:  util.YesNo(o.SslInboundInspection.BlockUnsupportedCipher, nil),
-			BlockUnsupportedVersion: util.YesNo(o.SslInboundInspection.BlockUnsupportedVersion, nil),
+			BlockIfHsmUnavailable:         util.YesNo(o.SslInboundInspection.BlockIfHsmUnavailable, nil),
+			BlockIfNoResource:             util.YesNo(o.SslInboundInspection.BlockIfNoResource, nil),
+			BlockTls13DowngradeNoResource: util.YesNo(o.SslInboundInspection.BlockTls13DowngradeNoResource, nil),
+			BlockUnsupportedCipher:        util.YesNo(o.SslInboundInspection.BlockUnsupportedCipher, nil),
+			BlockUnsupportedVersion:       util.YesNo(o.SslInboundInspection.BlockUnsupportedVersion, nil),
 		}
 	}
 
@@ -248,7 +248,6 @@ func specifyEntry(o *Entry) (any, error) {
 func (o entryXml) unmarshalToObject() (*Entry, error) {
 	result := &Entry{
 		Name:           o.Name,
-		Description:    o.Description,
 		Misc:           o.Misc,
 		MiscAttributes: o.MiscAttributes,
 	}
@@ -271,10 +270,11 @@ func (o entryXml) unmarshalToObject() (*Entry, error) {
 
 	if o.SslInboundInspection != nil {
 		result.SslInboundInspection = &SslInboundInspection{
-			BlockIfHsmUnavailable:   util.AsBool(o.SslInboundInspection.BlockIfHsmUnavailable, nil),
-			BlockIfNoResource:       util.AsBool(o.SslInboundInspection.BlockIfNoResource, nil),
-			BlockUnsupportedCipher:  util.AsBool(o.SslInboundInspection.BlockUnsupportedCipher, nil),
-			BlockUnsupportedVersion: util.AsBool(o.SslInboundInspection.BlockUnsupportedVersion, nil),
+			BlockIfHsmUnavailable:         util.AsBool(o.SslInboundInspection.BlockIfHsmUnavailable, nil),
+			BlockIfNoResource:             util.AsBool(o.SslInboundInspection.BlockIfNoResource, nil),
+			BlockTls13DowngradeNoResource: util.AsBool(o.SslInboundInspection.BlockTls13DowngradeNoResource, nil),
+			BlockUnsupportedCipher:        util.AsBool(o.SslInboundInspection.BlockUnsupportedCipher, nil),
+			BlockUnsupportedVersion:       util.AsBool(o.SslInboundInspection.BlockUnsupportedVersion, nil),
 		}
 	}
 
@@ -317,9 +317,6 @@ func (e *Entry) Field(v string) (any, error) {
 	if v == "name" || v == "Name" {
 		return e.Name, nil
 	}
-	if v == "description" || v == "Description" {
-		return e.Description, nil
-	}
 	if v == "ssl_forward_proxy" || v == "SslForwardProxy" {
 		return e.SslForwardProxy, nil
 	}
@@ -350,9 +347,6 @@ func SpecMatches(a, b *Entry) bool {
 }
 
 func (o *Entry) matches(other *Entry) bool {
-	if !util.StringsMatch(o.Description, other.Description) {
-		return false
-	}
 	if !o.SslForwardProxy.matches(other.SslForwardProxy) {
 		return false
 	}
@@ -422,6 +416,9 @@ func (o *SslInboundInspection) matches(other *SslInboundInspection) bool {
 		return false
 	}
 	if !util.BoolsMatch(o.BlockIfNoResource, other.BlockIfNoResource) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockTls13DowngradeNoResource, other.BlockTls13DowngradeNoResource) {
 		return false
 	}
 	if !util.BoolsMatch(o.BlockUnsupportedCipher, other.BlockUnsupportedCipher) {

--- a/objects/profiles/decryption/entry.go
+++ b/objects/profiles/decryption/entry.go
@@ -1,0 +1,520 @@
+package decryption
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"github.com/PaloAltoNetworks/pango/filtering"
+	"github.com/PaloAltoNetworks/pango/generic"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
+)
+
+var (
+	_ filtering.Fielder = &Entry{}
+)
+
+var (
+	Suffix = []string{"decryption"}
+)
+
+// Entry represents a PAN-OS decryption profile.
+type Entry struct {
+	Name                string
+	Description         *string
+	SslForwardProxy     *SslForwardProxy
+	SslInboundInspection *SslInboundInspection
+	SslNoProxy          *SslNoProxy
+	SslProtocolSettings *SslProtocolSettings
+
+	Misc           []generic.Xml
+	MiscAttributes []xml.Attr
+}
+
+type SslForwardProxy struct {
+	AutoIncludeAltname             *bool
+	BlockClientCert                *bool
+	BlockExpiredCertificate        *bool
+	BlockTimeoutCert               *bool
+	BlockTls13DowngradeNoResource  *bool
+	BlockUnknownCert               *bool
+	BlockUnsupportedCipher         *bool
+	BlockUnsupportedVersion        *bool
+	BlockUntrustedIssuer           *bool
+	RestrictCertExts               *bool
+	StripAlpn                      *bool
+}
+
+type SslInboundInspection struct {
+	BlockIfHsmUnavailable   *bool
+	BlockIfNoResource       *bool
+	BlockUnsupportedCipher  *bool
+	BlockUnsupportedVersion *bool
+}
+
+type SslNoProxy struct {
+	BlockClientCert         *bool
+	BlockExpiredCertificate *bool
+	BlockTimeoutCert        *bool
+	BlockUnknownCert        *bool
+	BlockUnsupportedCipher  *bool
+	BlockUnsupportedVersion *bool
+	BlockUntrustedIssuer    *bool
+}
+
+type SslProtocolSettings struct {
+	AuthAlgoMd5        *bool
+	AuthAlgoSha1       *bool
+	AuthAlgoSha256     *bool
+	AuthAlgoSha384     *bool
+	EncAlgo3des        *bool
+	EncAlgoAes128Cbc   *bool
+	EncAlgoAes128Gcm   *bool
+	EncAlgoAes256Cbc   *bool
+	EncAlgoAes256Gcm   *bool
+	EncAlgoRc4         *bool
+	KeyxchgAlgoDhe     *bool
+	KeyxchgAlgoEcdhe   *bool
+	KeyxchgAlgoRsa     *bool
+	MaxVersion         *string
+	MinVersion         *string
+}
+
+// EntryObject interface methods.
+
+func (o *Entry) EntryName() string {
+	return o.Name
+}
+
+func (o *Entry) SetEntryName(name string) {
+	o.Name = name
+}
+
+func (o *Entry) GetMiscAttributes() []xml.Attr {
+	return o.MiscAttributes
+}
+
+func (o *Entry) SetMiscAttributes(attrs []xml.Attr) {
+	o.MiscAttributes = attrs
+}
+
+// XML types.
+
+type entryXmlContainer struct {
+	Answer []entryXml `xml:"entry"`
+}
+
+type entryXml struct {
+	XMLName              xml.Name                  `xml:"entry"`
+	Name                 string                    `xml:"name,attr"`
+	Description          *string                   `xml:"description,omitempty"`
+	SslForwardProxy      *sslForwardProxyXml       `xml:"ssl-forward-proxy,omitempty"`
+	SslInboundInspection *sslInboundInspectionXml  `xml:"ssl-inbound-inspection,omitempty"`
+	SslNoProxy           *sslNoProxyXml            `xml:"ssl-no-proxy,omitempty"`
+	SslProtocolSettings  *sslProtocolSettingsXml   `xml:"ssl-protocol-settings,omitempty"`
+	Misc                 []generic.Xml             `xml:",any"`
+	MiscAttributes       []xml.Attr                `xml:",any,attr"`
+}
+
+type sslForwardProxyXml struct {
+	AutoIncludeAltname            *string `xml:"auto-include-altname,omitempty"`
+	BlockClientCert               *string `xml:"block-client-cert,omitempty"`
+	BlockExpiredCertificate       *string `xml:"block-expired-certificate,omitempty"`
+	BlockTimeoutCert              *string `xml:"block-timeout-cert,omitempty"`
+	BlockTls13DowngradeNoResource *string `xml:"block-tls13-downgrade-no-resource,omitempty"`
+	BlockUnknownCert              *string `xml:"block-unknown-cert,omitempty"`
+	BlockUnsupportedCipher        *string `xml:"block-unsupported-cipher,omitempty"`
+	BlockUnsupportedVersion       *string `xml:"block-unsupported-version,omitempty"`
+	BlockUntrustedIssuer          *string `xml:"block-untrusted-issuer,omitempty"`
+	RestrictCertExts              *string `xml:"restrict-cert-exts,omitempty"`
+	StripAlpn                     *string `xml:"strip-alpn,omitempty"`
+}
+
+type sslInboundInspectionXml struct {
+	BlockIfHsmUnavailable   *string `xml:"block-if-hsm-unavailable,omitempty"`
+	BlockIfNoResource       *string `xml:"block-if-no-resource,omitempty"`
+	BlockUnsupportedCipher  *string `xml:"block-unsupported-cipher,omitempty"`
+	BlockUnsupportedVersion *string `xml:"block-unsupported-version,omitempty"`
+}
+
+type sslNoProxyXml struct {
+	BlockClientCert         *string `xml:"block-client-cert,omitempty"`
+	BlockExpiredCertificate *string `xml:"block-expired-certificate,omitempty"`
+	BlockTimeoutCert        *string `xml:"block-timeout-cert,omitempty"`
+	BlockUnknownCert        *string `xml:"block-unknown-cert,omitempty"`
+	BlockUnsupportedCipher  *string `xml:"block-unsupported-cipher,omitempty"`
+	BlockUnsupportedVersion *string `xml:"block-unsupported-version,omitempty"`
+	BlockUntrustedIssuer    *string `xml:"block-untrusted-issuer,omitempty"`
+}
+
+type sslProtocolSettingsXml struct {
+	AuthAlgoMd5        *string `xml:"auth-algo-md5,omitempty"`
+	AuthAlgoSha1       *string `xml:"auth-algo-sha1,omitempty"`
+	AuthAlgoSha256     *string `xml:"auth-algo-sha256,omitempty"`
+	AuthAlgoSha384     *string `xml:"auth-algo-sha384,omitempty"`
+	EncAlgo3des        *string `xml:"enc-algo-3des,omitempty"`
+	EncAlgoAes128Cbc   *string `xml:"enc-algo-aes-128-cbc,omitempty"`
+	EncAlgoAes128Gcm   *string `xml:"enc-algo-aes-128-gcm,omitempty"`
+	EncAlgoAes256Cbc   *string `xml:"enc-algo-aes-256-cbc,omitempty"`
+	EncAlgoAes256Gcm   *string `xml:"enc-algo-aes-256-gcm,omitempty"`
+	EncAlgoRc4         *string `xml:"enc-algo-rc4,omitempty"`
+	KeyxchgAlgoDhe     *string `xml:"keyxchg-algo-dhe,omitempty"`
+	KeyxchgAlgoEcdhe   *string `xml:"keyxchg-algo-ecdhe,omitempty"`
+	KeyxchgAlgoRsa     *string `xml:"keyxchg-algo-rsa,omitempty"`
+	MaxVersion         *string `xml:"max-version,omitempty"`
+	MinVersion         *string `xml:"min-version,omitempty"`
+}
+
+func (o *entryXmlContainer) Normalize() ([]*Entry, error) {
+	entries := make([]*Entry, 0, len(o.Answer))
+	for _, elt := range o.Answer {
+		obj, err := elt.unmarshalToObject()
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, obj)
+	}
+	return entries, nil
+}
+
+func specifyEntry(o *Entry) (any, error) {
+	entry := entryXml{
+		Name:           o.Name,
+		Description:    o.Description,
+		Misc:           o.Misc,
+		MiscAttributes: o.MiscAttributes,
+	}
+
+	if o.SslForwardProxy != nil {
+		entry.SslForwardProxy = &sslForwardProxyXml{
+			AutoIncludeAltname:            util.YesNo(o.SslForwardProxy.AutoIncludeAltname, nil),
+			BlockClientCert:               util.YesNo(o.SslForwardProxy.BlockClientCert, nil),
+			BlockExpiredCertificate:       util.YesNo(o.SslForwardProxy.BlockExpiredCertificate, nil),
+			BlockTimeoutCert:              util.YesNo(o.SslForwardProxy.BlockTimeoutCert, nil),
+			BlockTls13DowngradeNoResource: util.YesNo(o.SslForwardProxy.BlockTls13DowngradeNoResource, nil),
+			BlockUnknownCert:              util.YesNo(o.SslForwardProxy.BlockUnknownCert, nil),
+			BlockUnsupportedCipher:        util.YesNo(o.SslForwardProxy.BlockUnsupportedCipher, nil),
+			BlockUnsupportedVersion:       util.YesNo(o.SslForwardProxy.BlockUnsupportedVersion, nil),
+			BlockUntrustedIssuer:          util.YesNo(o.SslForwardProxy.BlockUntrustedIssuer, nil),
+			RestrictCertExts:              util.YesNo(o.SslForwardProxy.RestrictCertExts, nil),
+			StripAlpn:                     util.YesNo(o.SslForwardProxy.StripAlpn, nil),
+		}
+	}
+
+	if o.SslInboundInspection != nil {
+		entry.SslInboundInspection = &sslInboundInspectionXml{
+			BlockIfHsmUnavailable:   util.YesNo(o.SslInboundInspection.BlockIfHsmUnavailable, nil),
+			BlockIfNoResource:       util.YesNo(o.SslInboundInspection.BlockIfNoResource, nil),
+			BlockUnsupportedCipher:  util.YesNo(o.SslInboundInspection.BlockUnsupportedCipher, nil),
+			BlockUnsupportedVersion: util.YesNo(o.SslInboundInspection.BlockUnsupportedVersion, nil),
+		}
+	}
+
+	if o.SslNoProxy != nil {
+		entry.SslNoProxy = &sslNoProxyXml{
+			BlockClientCert:         util.YesNo(o.SslNoProxy.BlockClientCert, nil),
+			BlockExpiredCertificate: util.YesNo(o.SslNoProxy.BlockExpiredCertificate, nil),
+			BlockTimeoutCert:        util.YesNo(o.SslNoProxy.BlockTimeoutCert, nil),
+			BlockUnknownCert:        util.YesNo(o.SslNoProxy.BlockUnknownCert, nil),
+			BlockUnsupportedCipher:  util.YesNo(o.SslNoProxy.BlockUnsupportedCipher, nil),
+			BlockUnsupportedVersion: util.YesNo(o.SslNoProxy.BlockUnsupportedVersion, nil),
+			BlockUntrustedIssuer:    util.YesNo(o.SslNoProxy.BlockUntrustedIssuer, nil),
+		}
+	}
+
+	if o.SslProtocolSettings != nil {
+		entry.SslProtocolSettings = &sslProtocolSettingsXml{
+			AuthAlgoMd5:        util.YesNo(o.SslProtocolSettings.AuthAlgoMd5, nil),
+			AuthAlgoSha1:       util.YesNo(o.SslProtocolSettings.AuthAlgoSha1, nil),
+			AuthAlgoSha256:     util.YesNo(o.SslProtocolSettings.AuthAlgoSha256, nil),
+			AuthAlgoSha384:     util.YesNo(o.SslProtocolSettings.AuthAlgoSha384, nil),
+			EncAlgo3des:        util.YesNo(o.SslProtocolSettings.EncAlgo3des, nil),
+			EncAlgoAes128Cbc:   util.YesNo(o.SslProtocolSettings.EncAlgoAes128Cbc, nil),
+			EncAlgoAes128Gcm:   util.YesNo(o.SslProtocolSettings.EncAlgoAes128Gcm, nil),
+			EncAlgoAes256Cbc:   util.YesNo(o.SslProtocolSettings.EncAlgoAes256Cbc, nil),
+			EncAlgoAes256Gcm:   util.YesNo(o.SslProtocolSettings.EncAlgoAes256Gcm, nil),
+			EncAlgoRc4:         util.YesNo(o.SslProtocolSettings.EncAlgoRc4, nil),
+			KeyxchgAlgoDhe:     util.YesNo(o.SslProtocolSettings.KeyxchgAlgoDhe, nil),
+			KeyxchgAlgoEcdhe:   util.YesNo(o.SslProtocolSettings.KeyxchgAlgoEcdhe, nil),
+			KeyxchgAlgoRsa:     util.YesNo(o.SslProtocolSettings.KeyxchgAlgoRsa, nil),
+			MaxVersion:         o.SslProtocolSettings.MaxVersion,
+			MinVersion:         o.SslProtocolSettings.MinVersion,
+		}
+	}
+
+	return entry, nil
+}
+
+func (o entryXml) unmarshalToObject() (*Entry, error) {
+	result := &Entry{
+		Name:           o.Name,
+		Description:    o.Description,
+		Misc:           o.Misc,
+		MiscAttributes: o.MiscAttributes,
+	}
+
+	if o.SslForwardProxy != nil {
+		result.SslForwardProxy = &SslForwardProxy{
+			AutoIncludeAltname:            util.AsBool(o.SslForwardProxy.AutoIncludeAltname, nil),
+			BlockClientCert:               util.AsBool(o.SslForwardProxy.BlockClientCert, nil),
+			BlockExpiredCertificate:       util.AsBool(o.SslForwardProxy.BlockExpiredCertificate, nil),
+			BlockTimeoutCert:              util.AsBool(o.SslForwardProxy.BlockTimeoutCert, nil),
+			BlockTls13DowngradeNoResource: util.AsBool(o.SslForwardProxy.BlockTls13DowngradeNoResource, nil),
+			BlockUnknownCert:              util.AsBool(o.SslForwardProxy.BlockUnknownCert, nil),
+			BlockUnsupportedCipher:        util.AsBool(o.SslForwardProxy.BlockUnsupportedCipher, nil),
+			BlockUnsupportedVersion:       util.AsBool(o.SslForwardProxy.BlockUnsupportedVersion, nil),
+			BlockUntrustedIssuer:          util.AsBool(o.SslForwardProxy.BlockUntrustedIssuer, nil),
+			RestrictCertExts:              util.AsBool(o.SslForwardProxy.RestrictCertExts, nil),
+			StripAlpn:                     util.AsBool(o.SslForwardProxy.StripAlpn, nil),
+		}
+	}
+
+	if o.SslInboundInspection != nil {
+		result.SslInboundInspection = &SslInboundInspection{
+			BlockIfHsmUnavailable:   util.AsBool(o.SslInboundInspection.BlockIfHsmUnavailable, nil),
+			BlockIfNoResource:       util.AsBool(o.SslInboundInspection.BlockIfNoResource, nil),
+			BlockUnsupportedCipher:  util.AsBool(o.SslInboundInspection.BlockUnsupportedCipher, nil),
+			BlockUnsupportedVersion: util.AsBool(o.SslInboundInspection.BlockUnsupportedVersion, nil),
+		}
+	}
+
+	if o.SslNoProxy != nil {
+		result.SslNoProxy = &SslNoProxy{
+			BlockClientCert:         util.AsBool(o.SslNoProxy.BlockClientCert, nil),
+			BlockExpiredCertificate: util.AsBool(o.SslNoProxy.BlockExpiredCertificate, nil),
+			BlockTimeoutCert:        util.AsBool(o.SslNoProxy.BlockTimeoutCert, nil),
+			BlockUnknownCert:        util.AsBool(o.SslNoProxy.BlockUnknownCert, nil),
+			BlockUnsupportedCipher:  util.AsBool(o.SslNoProxy.BlockUnsupportedCipher, nil),
+			BlockUnsupportedVersion: util.AsBool(o.SslNoProxy.BlockUnsupportedVersion, nil),
+			BlockUntrustedIssuer:    util.AsBool(o.SslNoProxy.BlockUntrustedIssuer, nil),
+		}
+	}
+
+	if o.SslProtocolSettings != nil {
+		result.SslProtocolSettings = &SslProtocolSettings{
+			AuthAlgoMd5:        util.AsBool(o.SslProtocolSettings.AuthAlgoMd5, nil),
+			AuthAlgoSha1:       util.AsBool(o.SslProtocolSettings.AuthAlgoSha1, nil),
+			AuthAlgoSha256:     util.AsBool(o.SslProtocolSettings.AuthAlgoSha256, nil),
+			AuthAlgoSha384:     util.AsBool(o.SslProtocolSettings.AuthAlgoSha384, nil),
+			EncAlgo3des:        util.AsBool(o.SslProtocolSettings.EncAlgo3des, nil),
+			EncAlgoAes128Cbc:   util.AsBool(o.SslProtocolSettings.EncAlgoAes128Cbc, nil),
+			EncAlgoAes128Gcm:   util.AsBool(o.SslProtocolSettings.EncAlgoAes128Gcm, nil),
+			EncAlgoAes256Cbc:   util.AsBool(o.SslProtocolSettings.EncAlgoAes256Cbc, nil),
+			EncAlgoAes256Gcm:   util.AsBool(o.SslProtocolSettings.EncAlgoAes256Gcm, nil),
+			EncAlgoRc4:         util.AsBool(o.SslProtocolSettings.EncAlgoRc4, nil),
+			KeyxchgAlgoDhe:     util.AsBool(o.SslProtocolSettings.KeyxchgAlgoDhe, nil),
+			KeyxchgAlgoEcdhe:   util.AsBool(o.SslProtocolSettings.KeyxchgAlgoEcdhe, nil),
+			KeyxchgAlgoRsa:     util.AsBool(o.SslProtocolSettings.KeyxchgAlgoRsa, nil),
+			MaxVersion:         o.SslProtocolSettings.MaxVersion,
+			MinVersion:         o.SslProtocolSettings.MinVersion,
+		}
+	}
+
+	return result, nil
+}
+
+func (e *Entry) Field(v string) (any, error) {
+	if v == "name" || v == "Name" {
+		return e.Name, nil
+	}
+	if v == "description" || v == "Description" {
+		return e.Description, nil
+	}
+	if v == "ssl_forward_proxy" || v == "SslForwardProxy" {
+		return e.SslForwardProxy, nil
+	}
+	if v == "ssl_inbound_inspection" || v == "SslInboundInspection" {
+		return e.SslInboundInspection, nil
+	}
+	if v == "ssl_no_proxy" || v == "SslNoProxy" {
+		return e.SslNoProxy, nil
+	}
+	if v == "ssl_protocol_settings" || v == "SslProtocolSettings" {
+		return e.SslProtocolSettings, nil
+	}
+	return nil, fmt.Errorf("unknown field")
+}
+
+func Versioning(vn version.Number) (Specifier, Normalizer, error) {
+	return specifyEntry, &entryXmlContainer{}, nil
+}
+
+func SpecMatches(a, b *Entry) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if (a == nil && b != nil) || (a != nil && b == nil) {
+		return false
+	}
+	return a.matches(b)
+}
+
+func (o *Entry) matches(other *Entry) bool {
+	if !util.StringsMatch(o.Description, other.Description) {
+		return false
+	}
+	if !o.SslForwardProxy.matches(other.SslForwardProxy) {
+		return false
+	}
+	if !o.SslInboundInspection.matches(other.SslInboundInspection) {
+		return false
+	}
+	if !o.SslNoProxy.matches(other.SslNoProxy) {
+		return false
+	}
+	if !o.SslProtocolSettings.matches(other.SslProtocolSettings) {
+		return false
+	}
+	return true
+}
+
+func (o *SslForwardProxy) matches(other *SslForwardProxy) bool {
+	if o == nil && other == nil {
+		return true
+	}
+	if (o == nil) != (other == nil) {
+		return false
+	}
+	if !util.BoolsMatch(o.AutoIncludeAltname, other.AutoIncludeAltname) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockClientCert, other.BlockClientCert) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockExpiredCertificate, other.BlockExpiredCertificate) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockTimeoutCert, other.BlockTimeoutCert) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockTls13DowngradeNoResource, other.BlockTls13DowngradeNoResource) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockUnknownCert, other.BlockUnknownCert) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockUnsupportedCipher, other.BlockUnsupportedCipher) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockUnsupportedVersion, other.BlockUnsupportedVersion) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockUntrustedIssuer, other.BlockUntrustedIssuer) {
+		return false
+	}
+	if !util.BoolsMatch(o.RestrictCertExts, other.RestrictCertExts) {
+		return false
+	}
+	if !util.BoolsMatch(o.StripAlpn, other.StripAlpn) {
+		return false
+	}
+	return true
+}
+
+func (o *SslInboundInspection) matches(other *SslInboundInspection) bool {
+	if o == nil && other == nil {
+		return true
+	}
+	if (o == nil) != (other == nil) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockIfHsmUnavailable, other.BlockIfHsmUnavailable) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockIfNoResource, other.BlockIfNoResource) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockUnsupportedCipher, other.BlockUnsupportedCipher) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockUnsupportedVersion, other.BlockUnsupportedVersion) {
+		return false
+	}
+	return true
+}
+
+func (o *SslNoProxy) matches(other *SslNoProxy) bool {
+	if o == nil && other == nil {
+		return true
+	}
+	if (o == nil) != (other == nil) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockClientCert, other.BlockClientCert) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockExpiredCertificate, other.BlockExpiredCertificate) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockTimeoutCert, other.BlockTimeoutCert) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockUnknownCert, other.BlockUnknownCert) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockUnsupportedCipher, other.BlockUnsupportedCipher) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockUnsupportedVersion, other.BlockUnsupportedVersion) {
+		return false
+	}
+	if !util.BoolsMatch(o.BlockUntrustedIssuer, other.BlockUntrustedIssuer) {
+		return false
+	}
+	return true
+}
+
+func (o *SslProtocolSettings) matches(other *SslProtocolSettings) bool {
+	if o == nil && other == nil {
+		return true
+	}
+	if (o == nil) != (other == nil) {
+		return false
+	}
+	if !util.BoolsMatch(o.AuthAlgoMd5, other.AuthAlgoMd5) {
+		return false
+	}
+	if !util.BoolsMatch(o.AuthAlgoSha1, other.AuthAlgoSha1) {
+		return false
+	}
+	if !util.BoolsMatch(o.AuthAlgoSha256, other.AuthAlgoSha256) {
+		return false
+	}
+	if !util.BoolsMatch(o.AuthAlgoSha384, other.AuthAlgoSha384) {
+		return false
+	}
+	if !util.BoolsMatch(o.EncAlgo3des, other.EncAlgo3des) {
+		return false
+	}
+	if !util.BoolsMatch(o.EncAlgoAes128Cbc, other.EncAlgoAes128Cbc) {
+		return false
+	}
+	if !util.BoolsMatch(o.EncAlgoAes128Gcm, other.EncAlgoAes128Gcm) {
+		return false
+	}
+	if !util.BoolsMatch(o.EncAlgoAes256Cbc, other.EncAlgoAes256Cbc) {
+		return false
+	}
+	if !util.BoolsMatch(o.EncAlgoAes256Gcm, other.EncAlgoAes256Gcm) {
+		return false
+	}
+	if !util.BoolsMatch(o.EncAlgoRc4, other.EncAlgoRc4) {
+		return false
+	}
+	if !util.BoolsMatch(o.KeyxchgAlgoDhe, other.KeyxchgAlgoDhe) {
+		return false
+	}
+	if !util.BoolsMatch(o.KeyxchgAlgoEcdhe, other.KeyxchgAlgoEcdhe) {
+		return false
+	}
+	if !util.BoolsMatch(o.KeyxchgAlgoRsa, other.KeyxchgAlgoRsa) {
+		return false
+	}
+	if !util.StringsMatch(o.MaxVersion, other.MaxVersion) {
+		return false
+	}
+	if !util.StringsMatch(o.MinVersion, other.MinVersion) {
+		return false
+	}
+	return true
+}

--- a/objects/profiles/decryption/interfaces.go
+++ b/objects/profiles/decryption/interfaces.go
@@ -1,0 +1,7 @@
+package decryption
+
+type Specifier func(*Entry) (any, error)
+
+type Normalizer interface {
+	Normalize() ([]*Entry, error)
+}

--- a/objects/profiles/decryption/location.go
+++ b/objects/profiles/decryption/location.go
@@ -1,0 +1,124 @@
+package decryption
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PaloAltoNetworks/pango/errors"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/version"
+)
+
+type ImportLocation interface {
+	XpathForLocation(version.Number, util.ILocation) ([]string, error)
+	MarshalPangoXML([]string) (string, error)
+	UnmarshalPangoXML([]byte) ([]string, error)
+}
+
+type Location struct {
+	Shared      *SharedLocation      `json:"shared,omitempty"`
+	DeviceGroup *DeviceGroupLocation `json:"device_group,omitempty"`
+}
+
+type SharedLocation struct{}
+
+type DeviceGroupLocation struct {
+	DeviceGroup    string `json:"device_group"`
+	PanoramaDevice string `json:"panorama_device"`
+}
+
+func NewSharedLocation() *Location {
+	return &Location{Shared: &SharedLocation{}}
+}
+
+func NewDeviceGroupLocation() *Location {
+	return &Location{DeviceGroup: &DeviceGroupLocation{
+		DeviceGroup:    "",
+		PanoramaDevice: "localhost.localdomain",
+	}}
+}
+
+func (o Location) IsValid() error {
+	count := 0
+	switch {
+	case o.Shared != nil:
+		count++
+	case o.DeviceGroup != nil:
+		if o.DeviceGroup.DeviceGroup == "" {
+			return fmt.Errorf("DeviceGroup is unspecified")
+		}
+		if o.DeviceGroup.PanoramaDevice == "" {
+			return fmt.Errorf("PanoramaDevice is unspecified")
+		}
+		count++
+	}
+	if count == 0 {
+		return fmt.Errorf("no path specified")
+	}
+	if count > 1 {
+		return fmt.Errorf("multiple paths specified: only one should be specified")
+	}
+	return nil
+}
+
+func (o Location) LocationFilter() *string {
+	if o.DeviceGroup != nil {
+		if o.DeviceGroup.DeviceGroup == "" {
+			return nil
+		}
+		return &o.DeviceGroup.DeviceGroup
+	}
+	return nil
+}
+
+func (o Location) XpathPrefix(vn version.Number) ([]string, error) {
+	var ans []string
+	switch {
+	case o.Shared != nil:
+		ans = []string{"config", "shared"}
+	case o.DeviceGroup != nil:
+		if o.DeviceGroup.DeviceGroup == "" {
+			return nil, fmt.Errorf("DeviceGroup is unspecified")
+		}
+		if o.DeviceGroup.PanoramaDevice == "" {
+			return nil, fmt.Errorf("PanoramaDevice is unspecified")
+		}
+		ans = []string{
+			"config",
+			"devices",
+			util.AsEntryXpath(o.DeviceGroup.PanoramaDevice),
+			"device-group",
+			util.AsEntryXpath(o.DeviceGroup.DeviceGroup),
+		}
+	default:
+		return nil, errors.NoLocationSpecifiedError
+	}
+	return ans, nil
+}
+
+func (o Location) XpathWithComponents(vn version.Number, components ...string) ([]string, error) {
+	if len(components) != 1 {
+		return nil, fmt.Errorf("invalid number of arguments for XpathWithComponents() call")
+	}
+
+	component := components[0]
+	if component != "entry" {
+		if !strings.HasPrefix(component, "entry[@name=\"]") && !strings.HasPrefix(component, "entry[@name='") {
+			return nil, errors.NewInvalidXpathComponentError(fmt.Sprintf("Name must be formatted as entry: %s", component))
+		}
+		if !strings.HasSuffix(component, "\"]") && !strings.HasSuffix(component, "']") {
+			return nil, errors.NewInvalidXpathComponentError(fmt.Sprintf("Name must be formatted as entry: %s", component))
+		}
+	}
+
+	ans, err := o.XpathPrefix(vn)
+	if err != nil {
+		return nil, err
+	}
+
+	ans = append(ans, "profiles")
+	ans = append(ans, "decryption")
+	ans = append(ans, components[0])
+
+	return ans, nil
+}

--- a/objects/profiles/decryption/service.go
+++ b/objects/profiles/decryption/service.go
@@ -1,0 +1,275 @@
+package decryption
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/PaloAltoNetworks/pango/errors"
+	"github.com/PaloAltoNetworks/pango/filtering"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/xmlapi"
+)
+
+type Service struct {
+	client util.PangoClient
+}
+
+func NewService(client util.PangoClient) *Service {
+	return &Service{client: client}
+}
+
+func (s *Service) Create(ctx context.Context, loc Location, entry *Entry) (*Entry, error) {
+	if entry.Name == "" {
+		return nil, errors.NameNotSpecifiedError
+	}
+	vn := s.client.Versioning()
+	path, err := loc.XpathWithComponents(vn, util.AsEntryXpath(entry.Name))
+	if err != nil {
+		return nil, err
+	}
+	if err = s.CreateWithXpath(ctx, util.AsXpath(path[:len(path)-1]), entry); err != nil {
+		return nil, err
+	}
+	return s.ReadWithXpath(ctx, util.AsXpath(path), "get")
+}
+
+func (s *Service) CreateWithXpath(ctx context.Context, xpath string, entry *Entry) error {
+	vn := s.client.Versioning()
+	specifier, _, err := Versioning(vn)
+	if err != nil {
+		return err
+	}
+	createSpec, err := specifier(entry)
+	if err != nil {
+		return err
+	}
+	cmd := &xmlapi.Config{
+		Action:  "set",
+		Xpath:   xpath,
+		Element: createSpec,
+		Target:  s.client.GetTarget(),
+	}
+	if _, _, err = s.client.Communicate(ctx, cmd, false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) Read(ctx context.Context, loc Location, name, action string) (*Entry, error) {
+	return s.read(ctx, loc, name, action)
+}
+
+func (s *Service) ReadWithXpath(ctx context.Context, xpath string, action string) (*Entry, error) {
+	vn := s.client.Versioning()
+	_, normalizer, err := Versioning(vn)
+	if err != nil {
+		return nil, err
+	}
+	cmd := &xmlapi.Config{
+		Action: action,
+		Xpath:  xpath,
+		Target: s.client.GetTarget(),
+	}
+	if _, _, err = s.client.Communicate(ctx, cmd, true, normalizer); err != nil {
+		if err.Error() == "No such node" && action == "show" {
+			return nil, errors.ObjectNotFound()
+		}
+		return nil, err
+	}
+	list, err := normalizer.Normalize()
+	if err != nil {
+		return nil, err
+	} else if len(list) != 1 {
+		return nil, fmt.Errorf("expected to %q 1 entry, got %d", action, len(list))
+	}
+	return list[0], nil
+}
+
+func (s *Service) read(ctx context.Context, loc Location, value, action string) (*Entry, error) {
+	if value == "" {
+		return nil, errors.NameNotSpecifiedError
+	}
+	vn := s.client.Versioning()
+	path, err := loc.XpathWithComponents(vn, value)
+	if err != nil {
+		return nil, err
+	}
+	return s.ReadWithXpath(ctx, util.AsXpath(path), action)
+}
+
+func (s *Service) Update(ctx context.Context, loc Location, entry *Entry, name string) (*Entry, error) {
+	if entry.Name == "" {
+		return nil, errors.NameNotSpecifiedError
+	}
+	xpath, err := loc.XpathWithComponents(s.client.Versioning(), entry.Name)
+	if err != nil {
+		return nil, err
+	}
+	if err = s.UpdateWithXpath(ctx, util.AsXpath(xpath), entry, name); err != nil {
+		return nil, err
+	}
+	return s.ReadWithXpath(ctx, util.AsXpath(xpath), "get")
+}
+
+func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *Entry, name string) error {
+	vn := s.client.Versioning()
+	updates := xmlapi.NewMultiConfig(2)
+	specifier, _, err := Versioning(vn)
+	if err != nil {
+		return err
+	}
+
+	var old *Entry
+	if name != "" && name != entry.Name {
+		old, err = s.ReadWithXpath(ctx, xpath, "get")
+		if err != nil {
+			return err
+		}
+		if old != nil {
+			return errors.ObjectExists
+		}
+		updates.Add(&xmlapi.Config{
+			Action:  "rename",
+			Xpath:   util.AsXpath(xpath),
+			NewName: entry.Name,
+			Target:  s.client.GetTarget(),
+		})
+	} else {
+		old, err = s.ReadWithXpath(ctx, xpath, "get")
+		if err != nil {
+			return err
+		}
+		if old == nil {
+			return errors.ObjectNotFound()
+		}
+		if SpecMatches(entry, old) {
+			return nil
+		}
+		updateSpec, err := specifier(entry)
+		if err != nil {
+			return err
+		}
+		updates.Add(&xmlapi.Config{
+			Action:  "edit",
+			Xpath:   util.AsXpath(xpath),
+			Element: updateSpec,
+			Target:  s.client.GetTarget(),
+		})
+	}
+
+	if len(updates.Operations) != 0 {
+		if _, _, _, err = s.client.MultiConfig(ctx, updates, false, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) Delete(ctx context.Context, loc Location, name ...string) error {
+	return s.delete(ctx, loc, name)
+}
+
+func (s *Service) delete(ctx context.Context, loc Location, values []string) error {
+	for _, value := range values {
+		if value == "" {
+			return errors.NameNotSpecifiedError
+		}
+	}
+	vn := s.client.Versioning()
+	deletes := xmlapi.NewMultiConfig(len(values))
+	for _, value := range values {
+		path, err := loc.XpathWithComponents(vn, util.AsEntryXpath(value))
+		if err != nil {
+			return err
+		}
+		deletes.Add(&xmlapi.Config{
+			Action: "delete",
+			Xpath:  util.AsXpath(path),
+			Target: s.client.GetTarget(),
+		})
+	}
+	_, _, _, err := s.client.MultiConfig(ctx, deletes, false, nil)
+	return err
+}
+
+func (s *Service) List(ctx context.Context, loc Location, action, filter, quote string) ([]*Entry, error) {
+	return s.list(ctx, loc, action, filter, quote)
+}
+
+func (s *Service) list(ctx context.Context, loc Location, action, filter, quote string) ([]*Entry, error) {
+	xpath, err := loc.XpathWithComponents(s.client.Versioning(), util.AsEntryXpath(""))
+	if err != nil {
+		return nil, err
+	}
+	return s.ListWithXpath(ctx, util.AsXpath(xpath), action, filter, quote)
+}
+
+func (s *Service) ListWithXpath(ctx context.Context, xpath string, action, filter, quote string) ([]*Entry, error) {
+	var logic *filtering.Group
+	if filter != "" {
+		var err error
+		logic, err = filtering.Parse(filter, quote)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	vn := s.client.Versioning()
+	_, normalizer, err := Versioning(vn)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := &xmlapi.Config{
+		Action: action,
+		Xpath:  util.AsXpath(xpath),
+		Target: s.client.GetTarget(),
+	}
+
+	if _, _, err = s.client.Communicate(ctx, cmd, true, normalizer); err != nil {
+		if err.Error() == "No such node" && action == "show" {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	listing, err := normalizer.Normalize()
+	if err != nil || logic == nil {
+		return listing, err
+	}
+
+	filtered := make([]*Entry, 0, len(listing))
+	for _, x := range listing {
+		ok, err := logic.Matches(x)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			filtered = append(filtered, x)
+		}
+	}
+	return filtered, nil
+}
+
+func (s *Service) filterEntriesByLocation(location Location, entries []*Entry) []*Entry {
+	filter := location.LocationFilter()
+	if filter == nil {
+		return entries
+	}
+	getLocAttribute := func(entry *Entry) *string {
+		for _, elt := range entry.GetMiscAttributes() {
+			if elt.Name.Local == "loc" {
+				return &elt.Value
+			}
+		}
+		return nil
+	}
+	var filtered []*Entry
+	for _, elt := range entries {
+		loc := getLocAttribute(elt)
+		if loc == nil || *loc == *filter {
+			filtered = append(filtered, elt)
+		}
+	}
+	return filtered
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It enables the terraform provider to create zone protection under network profile
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/PaloAltoNetworks/terraform-provider-panos/issues/425
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I have applied the changes against my own configuration on Panorama
<!--- Include details of your testing environment, and the tests you ran to -->
Tested against Panorama with a two-firewall OCI deployment.
<!--- see how your change affects other areas of the code, etc. -->
Verified profiles are created in the correct network template scope and assigned to zones successfully.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->


- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
